### PR TITLE
[Proposal 2]: Epoch Speedup

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -36,7 +36,19 @@ library Constants {
     uint256 private constant INITIAL_STAKE_MULTIPLE = 1e6; // 100 ESD -> 100M ESDS
 
     /* Epoch */
-    uint256 private constant EPOCH_PERIOD = 86400; // 1 day
+    struct EpochStrategy {
+        uint256 offset;
+        uint256 start;
+        uint256 period;
+    }
+
+    uint256 private constant PREVIOUS_EPOCH_OFFSET = 91;
+    uint256 private constant PREVIOUS_EPOCH_START = 1600905600;
+    uint256 private constant PREVIOUS_EPOCH_PERIOD = 86400;
+
+    uint256 private constant CURRENT_EPOCH_OFFSET = 0; // TODO: fill in
+    uint256 private constant CURRENT_EPOCH_START = 0; // TODO: fill in
+    uint256 private constant CURRENT_EPOCH_PERIOD = 28800;
 
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 7;
@@ -73,8 +85,20 @@ library Constants {
         return ORACLE_RESERVE_MINIMUM;
     }
 
-    function getEpochPeriod() internal pure returns (uint256) {
-        return EPOCH_PERIOD;
+    function getPreviousEpochStrategy() internal pure returns (EpochStrategy memory) {
+        return EpochStrategy({
+            offset: PREVIOUS_EPOCH_OFFSET,
+            start: PREVIOUS_EPOCH_START,
+            period: PREVIOUS_EPOCH_PERIOD
+        });
+    }
+
+    function getCurrentEpochStrategy() internal pure returns (EpochStrategy memory) {
+        return EpochStrategy({
+            offset: CURRENT_EPOCH_OFFSET,
+            start: CURRENT_EPOCH_START,
+            period: CURRENT_EPOCH_PERIOD
+        });
     }
 
     function getInitialStakeMultiple() internal pure returns (uint256) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -46,13 +46,15 @@ library Constants {
     uint256 private constant PREVIOUS_EPOCH_START = 1600905600;
     uint256 private constant PREVIOUS_EPOCH_PERIOD = 86400;
 
-    uint256 private constant CURRENT_EPOCH_OFFSET = 0; // TODO: fill in
-    uint256 private constant CURRENT_EPOCH_START = 0; // TODO: fill in
+    uint256 private constant CURRENT_EPOCH_OFFSET = 107; // TODO: update before proposal
+    uint256 private constant CURRENT_EPOCH_START = 1602288000; // TODO: update before proposal
     uint256 private constant CURRENT_EPOCH_PERIOD = 28800;
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 7;
+    uint256 private constant GOVERNANCE_PERIOD = 9;
     uint256 private constant GOVERNANCE_QUORUM = 33e16; // 33%
+    uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
+    uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
     /* DAO */
     uint256 private constant ADVANCE_INCENTIVE = 1e20; // 100 ESD
@@ -123,6 +125,14 @@ library Constants {
 
     function getGovernanceQuorum() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: GOVERNANCE_QUORUM});
+    }
+
+    function getGovernanceSuperMajority() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: GOVERNANCE_SUPER_MAJORITY});
+    }
+
+    function getGovernanceEmergencyDelay() internal pure returns (uint256) {
+        return GOVERNANCE_EMERGENCY_DELAY;
     }
 
     function getAdvanceIncentive() internal pure returns (uint256) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -46,8 +46,8 @@ library Constants {
     uint256 private constant PREVIOUS_EPOCH_START = 1600905600;
     uint256 private constant PREVIOUS_EPOCH_PERIOD = 86400;
 
-    uint256 private constant CURRENT_EPOCH_OFFSET = 107; // TODO: update before proposal
-    uint256 private constant CURRENT_EPOCH_START = 1602288000; // TODO: update before proposal
+    uint256 private constant CURRENT_EPOCH_OFFSET = 106;
+    uint256 private constant CURRENT_EPOCH_START = 1602201600;
     uint256 private constant CURRENT_EPOCH_PERIOD = 28800;
 
     /* Governance */

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -142,16 +142,21 @@ contract Getters is State {
         Constants.EpochStrategy memory current = Constants.getCurrentEpochStrategy();
         Constants.EpochStrategy memory previous = Constants.getPreviousEpochStrategy();
 
-        return block.timestamp < current.start ?
+        return blockTimestamp() < current.start ?
             epochTimeWithStrategy(previous) :
             epochTimeWithStrategy(current);
     }
 
     function epochTimeWithStrategy(Constants.EpochStrategy memory strategy) private view returns (uint256) {
-        return block.timestamp
+        return blockTimestamp()
             .sub(strategy.start)
             .div(strategy.period)
             .add(strategy.offset);
+    }
+
+    // Overridable for testing
+    function blockTimestamp() internal view returns (uint256) {
+        return block.timestamp;
     }
 
     function outstandingCoupons(uint256 epoch) public view returns (uint256) {

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -116,6 +116,34 @@ contract Govern is Setters, Permission, Upgradeable {
         emit Commit(msg.sender, candidate);
     }
 
+    function emergencyCommit(address candidate) external {
+        Require.that(
+            isNominated(candidate),
+            FILE,
+            "Not nominated"
+        );
+
+        Require.that(
+            epochTime() > epoch().add(Constants.getGovernanceEmergencyDelay()),
+            FILE,
+            "Epoch synced"
+        );
+
+        Require.that(
+            Decimal.ratio(approveFor(candidate), totalBonded()).greaterThan(Constants.getGovernanceSuperMajority()),
+            FILE,
+            "Must have super majority"
+        );
+
+        Require.that(
+            approveFor(candidate) > rejectFor(candidate),
+            FILE,
+            "Not approved"
+        );
+        upgradeTo(candidate);
+        emit Commit(msg.sender, candidate);
+    }
+
     function canPropose(address account) private view returns (bool) {
         if (totalBonded() == 0) {
             return false;

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -140,7 +140,9 @@ contract Govern is Setters, Permission, Upgradeable {
             FILE,
             "Not approved"
         );
+
         upgradeTo(candidate);
+        
         emit Commit(msg.sender, candidate);
     }
 

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -142,7 +142,7 @@ contract Govern is Setters, Permission, Upgradeable {
         );
 
         upgradeTo(candidate);
-        
+
         emit Commit(msg.sender, candidate);
     }
 

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,8 +31,11 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        //TODO: replace with deployed pool
-        _state.provider.pool = address(0xA5976897BC0081e3895013B08654DfEc50Bcb33F);
+        _state.epoch.start = 0;
+        _state.epoch.period = 0;
+
+        // Reward committer
+        mintToAccount(msg.sender, Constants.getAdvanceIncentive());
     }
 
     function advance() external incentivized {

--- a/protocol/contracts/mock/MockGovern.sol
+++ b/protocol/contracts/mock/MockGovern.sol
@@ -22,6 +22,8 @@ import "./MockUpgradeable.sol";
 import "./MockComptroller.sol";
 
 contract MockGovern is Govern, MockComptroller {
+    uint256 internal _epochTime;
+
     constructor() MockComptroller(address(0)) public { }
 
     function initialize() public {
@@ -30,5 +32,13 @@ contract MockGovern is Govern, MockComptroller {
 
     function upgradeToE(address newImplementation) external {
         super.upgradeTo(newImplementation);
+    }
+
+    function setEpochTime(uint256 epochTime) external {
+        _epochTime = epochTime;
+    }
+
+    function epochTime() public view returns (uint256) {
+        return _epochTime;
     }
 }

--- a/protocol/contracts/mock/MockState.sol
+++ b/protocol/contracts/mock/MockState.sol
@@ -20,7 +20,11 @@ pragma experimental ABIEncoderV2;
 import "../dao/Setters.sol";
 
 contract MockState is Setters {
-    constructor () public { }
+    uint256 internal _blockTimestamp;
+
+    constructor () public {
+        _blockTimestamp = block.timestamp;
+    }
 
     /**
      * Global
@@ -149,5 +153,17 @@ contract MockState is Setters {
 
     function initializedE(address candidate) external {
         super.initialized(candidate);
+    }
+
+    /**
+     * Mock
+     */
+
+    function setBlockTimestamp(uint256 timestamp) external {
+        _blockTimestamp = timestamp;
+    }
+
+    function blockTimestamp() internal view returns (uint256) {
+        return _blockTimestamp;
     }
 }

--- a/protocol/test/dao/State.test.js
+++ b/protocol/test/dao/State.test.js
@@ -531,9 +531,29 @@ describe('State', function () {
       });
     });
 
-    describe('before update advance', function () {
+    describe('one before update advance', function () {
       beforeEach('call', async function () {
-        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (16 * 86400) - 1);
+        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (14 * 86400));
+      });
+
+      it('has advanced', async function () {
+        expect(await this.setters.epochTime()).to.be.bignumber.equal(new BN(105));
+      });
+    });
+
+    describe('right before update advance', function () {
+      beforeEach('call', async function () {
+        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (15 * 86400) - 1);
+      });
+
+      it('has advanced', async function () {
+        expect(await this.setters.epochTime()).to.be.bignumber.equal(new BN(105));
+      });
+    });
+
+    describe('at update advance', function () {
+      beforeEach('call', async function () {
+        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (15 * 86400));
       });
 
       it('has advanced', async function () {
@@ -541,9 +561,9 @@ describe('State', function () {
       });
     });
 
-    describe('at update advance', function () {
+    describe('at first after update advance', function () {
       beforeEach('call', async function () {
-        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (16 * 86400));
+        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (15 * 86400) + 28800);
       });
 
       it('has advanced', async function () {
@@ -551,23 +571,13 @@ describe('State', function () {
       });
     });
 
-    describe('at first after update advance', function () {
-      beforeEach('call', async function () {
-        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (16 * 86400) + 28800);
-      });
-
-      it('has advanced', async function () {
-        expect(await this.setters.epochTime()).to.be.bignumber.equal(new BN(108));
-      });
-    });
-
     describe('many after update advance', function () {
       beforeEach('call', async function () {
-        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (16 * 86400) + (10 * 28800));
+        await this.setters.setBlockTimestamp(BOOTSTRAPPING_END_TIMESTAMP + (15 * 86400) + (10 * 28800));
       });
 
       it('has advanced', async function () {
-        expect(await this.setters.epochTime()).to.be.bignumber.equal(new BN(117));
+        expect(await this.setters.epochTime()).to.be.bignumber.equal(new BN(116));
       });
     });
   });


### PR DESCRIPTION
# Proposal 2: Epoch Speedup

## Summary
- Shorten epoch period from `24 hours` to `8 hours`, starting at epoch `106`.
- Adds `emergencyCommit` method to governance.

## Description
#### Shorten Epoch
Starting at epoch `106` the epoch period will be shortened to `8 hours` allowing for faster regulations to the underlying system. This change deprecates `_state.epoch.start`, `_state.epoch.period`, and their getters, and also refactors `epochTime()` logic for easier schedule modifications in the future.

#### Emergency Commit
In the interest of recoverability during disaster scenarios, we've added an `emergencyCommit()` method to governance that allows an implementation to be committed under the following conditions:
- The stored epoch is `6 epochs` late vs `epochTime()`. 
- A `66%` supermajority approves the upgrade.

This intends to solve the case of a revert-causing bug bricking the advance function, which would otherwise halt the entire protocol. With this change after `6 x epoch periods` the protocol could vote in a fix with a supermajority of approvers. 

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Implementation: https://etherscan.io/address/0xcbaBfc142D6c3D4B3E83744132785A25ef967cC4
Status: Proposal