### PR TITLE
[Proposal] 3: Raise Debt Cap to 35%

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -61,6 +61,7 @@ library Constants {
 
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 90;
+    uint256 private constant DEBT_RATIO_CAP = 35e16; // 35%
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 1e17; // 10%
@@ -141,6 +142,10 @@ library Constants {
 
     function getCouponExpiration() internal pure returns (uint256) {
         return COUPON_EXPIRATION;
+    }
+
+    function getDebtRatioCap() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: DEBT_RATIO_CAP});
     }
 
     function getSupplyChangeLimit() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -59,6 +59,7 @@ contract Comptroller is Setters {
 
     function increaseDebt(uint256 amount) internal {
         incrementTotalDebt(amount);
+        resetDebt(Constants.getDebtRatioCap());
 
         balanceCheck();
     }
@@ -101,6 +102,16 @@ contract Comptroller is Setters {
         }
 
         return (newRedeemable, lessDebt, newSupply);
+    }
+
+    function resetDebt(Decimal.D256 memory targetDebtRatio) internal {
+        uint256 targetDebt = targetDebtRatio.mul(dollar().totalSupply()).asUint256();
+        uint256 currentDebt = totalDebt();
+
+        if (currentDebt > targetDebt) {
+            uint256 lessDebt = currentDebt.sub(targetDebt);
+            decreaseDebt(lessDebt);
+        }
     }
 
     function balanceCheck() private {

--- a/protocol/contracts/dao/Curve.sol
+++ b/protocol/contracts/dao/Curve.sol
@@ -19,6 +19,7 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../external/Decimal.sol";
+import "../Constants.sol";
 
 contract Curve {
     using SafeMath for uint256;
@@ -38,7 +39,7 @@ contract Curve {
         uint256 amount
     ) private pure returns (Decimal.D256 memory) {
         Decimal.D256 memory debtRatio = Decimal.ratio(totalDebt, totalSupply);
-        Decimal.D256 memory debtRatioUpperBound = debtRatioUpperBound();
+        Decimal.D256 memory debtRatioUpperBound = Constants.getDebtRatioCap();
 
         uint256 totalSupplyEnd = totalSupply.sub(amount);
         uint256 totalDebtEnd = totalDebt.sub(amount);
@@ -79,10 +80,5 @@ contract Curve {
         return Decimal.one().div(
             Decimal.from(3).mul(Decimal.one().sub(upper)).mul(Decimal.one().sub(lower))
         ).sub(Decimal.ratio(1, 3));
-    }
-
-    // 30%
-    function debtRatioUpperBound() private pure returns (Decimal.D256 memory) {
-        return Decimal.ratio(30, 100);
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,8 +31,8 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        _state.epoch.start = 0;
-        _state.epoch.period = 0;
+        // Reset debt to 30% if above
+        resetDebt(Decimal.ratio(30, 100));
 
         // Reward committer
         mintToAccount(msg.sender, Constants.getAdvanceIncentive());

--- a/protocol/contracts/mock/MockComptroller.sol
+++ b/protocol/contracts/mock/MockComptroller.sol
@@ -51,6 +51,10 @@ contract MockComptroller is Comptroller, MockState {
         super.decreaseDebt(amount);
     }
 
+    function resetDebtE(uint256 percent) external {
+        super.resetDebt(Decimal.ratio(percent, 100));
+    }
+
     /* For testing only */
     function mintToE(address account, uint256 amount) external {
         dollar().mint(account, amount);

--- a/protocol/test/dao/Comptroller.test.js
+++ b/protocol/test/dao/Comptroller.test.js
@@ -9,7 +9,7 @@ const Dollar = contract.fromArtifact('Dollar');
 const BOOTSTRAPPING_PERIOD = 90;
 
 describe('Comptroller', function () {
-  const [ ownerAddress, userAddress, poolAddress ] = accounts;
+  const [ ownerAddress, userAddress, poolAddress, circulating ] = accounts;
 
   beforeEach(async function () {
     this.comptroller = await MockComptroller.new(poolAddress, {from: ownerAddress, gas: 8000000});
@@ -17,6 +17,12 @@ describe('Comptroller', function () {
   });
 
   describe('mintToAccount', function () {
+    beforeEach(async function () {
+      await this.comptroller.mintToAccountE(circulating, new BN(10000));
+      const debt = await this.comptroller.totalDebt();
+      await this.comptroller.decreaseDebtE(debt);
+    });
+
     describe('bootstrapping', function () {
       describe('on single call', function () {
         beforeEach(async function () {
@@ -24,7 +30,7 @@ describe('Comptroller', function () {
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(100));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10100));
           expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
           expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(100));
         });
@@ -41,7 +47,7 @@ describe('Comptroller', function () {
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(300));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10300));
           expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
           expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(300));
         });
@@ -67,7 +73,7 @@ describe('Comptroller', function () {
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(100));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10100));
           expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
           expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(100));
         });
@@ -84,7 +90,7 @@ describe('Comptroller', function () {
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(300));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10300));
           expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
           expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(300));
         });
@@ -98,6 +104,10 @@ describe('Comptroller', function () {
 
   describe('burnFromAccount', function () {
     beforeEach(async function () {
+      await this.comptroller.mintToAccountE(circulating, new BN(10000));
+      const debt = await this.comptroller.totalDebt();
+      await this.comptroller.decreaseDebtE(debt);
+
       await this.comptroller.mintToE(userAddress, new BN(1000));
       await this.comptroller.increaseDebtE(new BN(1000));
       await this.dollar.approve(this.comptroller.address, new BN(1000), {from: userAddress});
@@ -109,7 +119,7 @@ describe('Comptroller', function () {
       });
 
       it('destroys Dollar tokens', async function () {
-        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(900));
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10900));
         expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
         expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(900));
       });
@@ -126,7 +136,7 @@ describe('Comptroller', function () {
       });
 
       it('destroys Dollar tokens', async function () {
-        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(700));
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10700));
         expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
         expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(700));
       });
@@ -228,8 +238,24 @@ describe('Comptroller', function () {
     });
 
     describe('increase past supply', function () {
-      it('reverts', async function () {
-        await expectRevert(this.comptroller.increaseDebtE(new BN(1100)), "Debt too large");
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(100));
+        await this.comptroller.increaseDebtE(new BN(300));
+      });
+
+      it('updates total debt', async function () {
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(350));
+      });
+    });
+
+    describe('increase past supply', function () {
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(100));
+        await this.comptroller.increaseDebtE(new BN(1000));
+      });
+
+      it('updates total debt', async function () {
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(350));
       });
     });
   });
@@ -237,7 +263,7 @@ describe('Comptroller', function () {
   describe('decreaseDebt', function () {
     beforeEach(async function () {
       await this.comptroller.mintToE(userAddress, new BN(1000));
-      await this.comptroller.increaseDebtE(new BN(1000))
+      await this.comptroller.increaseDebtE(new BN(350))
     });
 
     describe('on single call', function () {
@@ -246,7 +272,7 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(900));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(250));
       });
     });
 
@@ -257,13 +283,58 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(700));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(50));
       });
     });
 
-    describe('increase past supply', function () {
+    describe('decrease past supply', function () {
       it('reverts', async function () {
-        await expectRevert(this.comptroller.decreaseDebtE(new BN(1100)), "not enough debt");
+        await expectRevert(this.comptroller.decreaseDebtE(new BN(400)), "not enough debt");
+      });
+    });
+  });
+
+  describe('resetDebt', function () {
+    beforeEach(async function () {
+      await this.comptroller.mintToE(this.comptroller.address, new BN(10000));
+      const debt = await this.comptroller.totalDebt();
+      await this.comptroller.decrementTotalDebtE(debt, "");
+      await this.comptroller.incrementTotalBondedE(new BN(10000));
+    });
+
+    describe('excess debt', function () {
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(5000));
+        await this.comptroller.resetDebtE(new BN(30));
+      });
+
+      it('decreases debt', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(3000));
+      });
+    });
+
+    describe('equal debt', function () {
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(3000));
+        await this.comptroller.resetDebtE(new BN(30));
+      });
+
+      it('debt unchanged', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(3000));
+      });
+    });
+
+    describe('less debt', function () {
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(1000));
+        await this.comptroller.resetDebtE(new BN(30));
+      });
+
+      it('debt unchanged', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(1000));
       });
     });
   });

--- a/protocol/test/dao/Curve.test.js
+++ b/protocol/test/dao/Curve.test.js
@@ -1,6 +1,6 @@
 const { accounts, contract } = require('@openzeppelin/test-environment');
 
-const { BN, expectRevert, time } = require('@openzeppelin/test-helpers');
+const { BN, expectRevert } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
 const MockCurve = contract.fromArtifact('MockCurve');
@@ -60,20 +60,20 @@ describe('Curve', function () {
     });
   });
 
-  describe('100000-50000-10000: 0.346939 (above threshold) - should add 3469', function () {
+  describe('100000-70000-10000: 0.455621 (above threshold) - should add 4556', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 50000, 10000)).to.be.bignumber.equal(new BN(3469));
+      expect(await this.curve.calculateCouponsE(100000, 70000, 10000)).to.be.bignumber.equal(new BN(4556));
     });
   });
 
-  /* 40000/100000 -> 20000/80000
-   * 0.4 -> 0.25
-   * 0.3 - 0.4 (above threshold) + 0.25 - 0.3 (below threshold)
-   * (0.1 * 0.346939 + 0.05 * 0.301587) / 0.15 = 0.331822
+  /* 60000/100000 -> 10000/50000
+   * 0.6 -> 0.1
+   * 0.6 - 0.35 (above threshold) + 0.2 - 0.35 (below threshold)
+   * (0.25 * 0.455621 + 0.15 * 0.307692) / 0.4 = 0.400148
    */
-  describe('100000-40000-20000: 6636.44 (above and below threshold) - should add 6636', function () {
+  describe('100000-60000-50000: 6636.44 (above and below threshold) - should add 6636', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 40000, 20000)).to.be.bignumber.equal(new BN(6636));
+      expect(await this.curve.calculateCouponsE(100000, 60000, 50000)).to.be.bignumber.equal(new BN(20007));
     });
   });
 });


### PR DESCRIPTION
# Proposal 3: Raise Debt Cap to 35%

## Summary
- Raises debt cap from `30%` to `35%`.
- Resets debt ratio to `30%` if debt ratio is higher at time of commit.

## Description
#### Raise Debt Cap
During the most recent supply contraction period the protocol exceeded its previous debt cap of `30%` translating to a maximum `~34%` coupon premium. This proposal raises the debt cap to `35%` resulting in a maximum `~45%` coupon premium.

#### Debt Ratio Reset
Additionally, if the debt ratio is still above `30%` at time of proposal commit, it will be reset to `30%`. This is to prevent a sudden jump in coupon premium, since the coupon premium would not have been priced in after the `30%` cap.

#### Debt Cap
Further, debt will no longer continue to increase over the cap as this is not productive for pricing the premium.

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Implementation: https://etherscan.io/address/0x2519F663f9eEEF84D85e607D63C39C1B6fe885A4
Status: Proposal