### PR TITLE
[Proposal] 4: Fix Quorum Computation

### DIFF
--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -130,7 +130,7 @@ contract Govern is Setters, Permission, Upgradeable {
         );
 
         Require.that(
-            Decimal.ratio(approveFor(candidate), totalBonded()).greaterThan(Constants.getGovernanceSuperMajority()),
+            Decimal.ratio(approveFor(candidate), totalSupply()).greaterThan(Constants.getGovernanceSuperMajority()),
             FILE,
             "Must have super majority"
         );
@@ -151,7 +151,7 @@ contract Govern is Setters, Permission, Upgradeable {
             return false;
         }
 
-        Decimal.D256 memory stake = Decimal.ratio(balanceOf(account), totalBonded());
+        Decimal.D256 memory stake = Decimal.ratio(balanceOf(account), totalSupply());
         return stake.greaterThan(Decimal.ratio(1, 100)); // 1%
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,9 +31,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // Reset debt to 30% if above
-        resetDebt(Decimal.ratio(30, 100));
-
         // Reward committer
         mintToAccount(msg.sender, Constants.getAdvanceIncentive());
     }

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -132,7 +132,7 @@ contract Setters is State, Getters {
     }
 
     function snapshotTotalBonded() internal {
-        _state.epochs[epoch()].bonded = totalBonded();
+        _state.epochs[epoch()].bonded = totalSupply();
     }
 
     function initializeCouponsExpiration(uint256 epoch, uint256 expiration) internal {

--- a/protocol/test/dao/Bonding.test.js
+++ b/protocol/test/dao/Bonding.test.js
@@ -807,9 +807,9 @@ describe('Bonding', function () {
 
     it('has correct snapshots', async function () {
       expect(await this.bonding.totalBondedAt(0)).to.be.bignumber.equal(new BN(0));
-      expect(await this.bonding.totalBondedAt(1)).to.be.bignumber.equal(new BN(1000));
-      expect(await this.bonding.totalBondedAt(2)).to.be.bignumber.equal(new BN(4000));
-      expect(await this.bonding.totalBondedAt(3)).to.be.bignumber.equal(new BN(2000));
+      expect(await this.bonding.totalBondedAt(1)).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
+      expect(await this.bonding.totalBondedAt(2)).to.be.bignumber.equal(new BN(2000).mul(INITIAL_STAKE_MULTIPLE));
+      expect(await this.bonding.totalBondedAt(3)).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
     });
   });
 });

--- a/protocol/test/dao/Govern.test.js
+++ b/protocol/test/dao/Govern.test.js
@@ -15,6 +15,8 @@ const UNDECIDED = new BN(0);
 const APPROVE = new BN(1);
 const REJECT = new BN(2);
 
+const INITIAL_STAKE_MULTIPLE = new BN(10).pow(new BN(6)); // 100 ESD -> 100M ESDS
+
 describe('Govern', function () {
   const [ ownerAddress, userAddress, userAddress2, userAddress3 ] = accounts;
 
@@ -39,8 +41,8 @@ describe('Govern', function () {
 
       describe('when not enough stake to propose', function () {
         beforeEach(async function () {
-          await this.govern.incrementBalanceOfE(userAddress, 1);
-          await this.govern.incrementBalanceOfE(userAddress2, 999);
+          await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(1));
+          await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(999));
           await this.govern.incrementTotalBondedE(1000);
         });
 
@@ -51,8 +53,8 @@ describe('Govern', function () {
 
       describe('when ended', function () {
         beforeEach(async function () {
-          await this.govern.incrementBalanceOfE(userAddress, 1000);
-          await this.govern.incrementBalanceOfE(userAddress2, 1000);
+          await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(1000));
+          await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(1000));
           await this.govern.incrementTotalBondedE(2000);
 
           await this.govern.vote(this.implB.address, APPROVE, {from: userAddress2});
@@ -87,9 +89,9 @@ describe('Govern', function () {
 
     describe('can vote', function () {
       beforeEach(async function () {
-        await this.govern.incrementBalanceOfE(userAddress, 1000);
-        await this.govern.incrementBalanceOfE(userAddress2, 1000);
-        await this.govern.incrementBalanceOfE(userAddress3, 1000);
+        await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(1000));
+        await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(1000));
+        await this.govern.incrementBalanceOfE(userAddress3, INITIAL_STAKE_MULTIPLE.muln(1000));
         await this.govern.incrementTotalBondedE(3000);
       });
 
@@ -100,7 +102,7 @@ describe('Govern', function () {
         });
 
         it('sets vote counter correctly', async function () {
-          expect(await this.govern.approveFor(this.implB.address)).to.be.bignumber.equal(new BN(1000));
+          expect(await this.govern.approveFor(this.implB.address)).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
           expect(await this.govern.rejectFor(this.implB.address)).to.be.bignumber.equal(new BN(0));
         });
 
@@ -123,7 +125,7 @@ describe('Govern', function () {
           });
 
           expect(event.args.vote).to.be.bignumber.equal(APPROVE);
-          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000));
+          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
         });
 
         it('emits Proposal event', async function () {
@@ -176,8 +178,8 @@ describe('Govern', function () {
         });
 
         it('sets vote counter correctly', async function () {
-          expect(await this.govern.approveFor(this.implB.address)).to.be.bignumber.equal(new BN(2000));
-          expect(await this.govern.rejectFor(this.implB.address)).to.be.bignumber.equal(new BN(1000));
+          expect(await this.govern.approveFor(this.implB.address)).to.be.bignumber.equal(new BN(2000).mul(INITIAL_STAKE_MULTIPLE));
+          expect(await this.govern.rejectFor(this.implB.address)).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
         });
 
         it('is nominated', async function () {
@@ -203,7 +205,7 @@ describe('Govern', function () {
           });
 
           expect(event.args.vote).to.be.bignumber.equal(APPROVE);
-          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000));
+          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
         });
       });
 
@@ -220,7 +222,7 @@ describe('Govern', function () {
 
         it('sets vote counter correctly', async function () {
           expect(await this.govern.approveFor(this.implB.address)).to.be.bignumber.equal(new BN(0));
-          expect(await this.govern.rejectFor(this.implB.address)).to.be.bignumber.equal(new BN(2000));
+          expect(await this.govern.rejectFor(this.implB.address)).to.be.bignumber.equal(new BN(2000).mul(INITIAL_STAKE_MULTIPLE));
         });
 
         it('is nominated', async function () {
@@ -246,7 +248,7 @@ describe('Govern', function () {
           });
 
           expect(event.args.vote).to.be.bignumber.equal(REJECT);
-          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000));
+          expect(event.args.bonded).to.be.bignumber.equal(new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
         });
       });
     });
@@ -254,9 +256,9 @@ describe('Govern', function () {
 
   describe('commit', function () {
     beforeEach(async function () {
-      await this.govern.incrementBalanceOfE(userAddress, 2500);
-      await this.govern.incrementBalanceOfE(userAddress2, 4000);
-      await this.govern.incrementBalanceOfE(userAddress3, 3500);
+      await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(2500));
+      await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(4000));
+      await this.govern.incrementBalanceOfE(userAddress3, INITIAL_STAKE_MULTIPLE.muln(3500));
       await this.govern.incrementTotalBondedE(10000);
     });
 
@@ -356,9 +358,9 @@ describe('Govern', function () {
 
   describe('emergency commit', function () {
     beforeEach(async function () {
-      await this.govern.incrementBalanceOfE(userAddress, 2500);
-      await this.govern.incrementBalanceOfE(userAddress2, 4000);
-      await this.govern.incrementBalanceOfE(userAddress3, 3500);
+      await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(2500));
+      await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(4000));
+      await this.govern.incrementBalanceOfE(userAddress3, INITIAL_STAKE_MULTIPLE.muln(3500));
       await this.govern.incrementTotalBondedE(10000);
 
       const epoch = await this.govern.epoch();

--- a/protocol/test/dao/State.test.js
+++ b/protocol/test/dao/State.test.js
@@ -624,7 +624,7 @@ describe('State', function () {
 
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.setters.incrementTotalBondedE(100);
+        await this.setters.incrementBalanceOfE(userAddress, 100);
         await this.setters.snapshotTotalBondedE();
       });
 
@@ -635,11 +635,11 @@ describe('State', function () {
 
     describe('when called multiple times', function () {
       beforeEach('call', async function () {
-        await this.setters.incrementTotalBondedE(100);
+        await this.setters.incrementBalanceOfE(userAddress, 100);
         await this.setters.snapshotTotalBondedE();
         await this.setters.incrementEpochE();
 
-        await this.setters.incrementTotalBondedE(100);
+        await this.setters.incrementBalanceOfE(userAddress, 100);
         await this.setters.snapshotTotalBondedE();
       });
 


### PR DESCRIPTION
# Proposal 4: Fix Quorum Computation

## Summary
- Resolves bug that allows proposal and commitment with less `ESDS` than expected.

## Description
#### Quorum Bug
In the initial implementation:
- A user's DAO stake % was erroneously calculated as `balanceOf(account) / totalBonded()` for proposing.
- Quorum % was erroneously calculated as `votesFor(candidate) / totalBonded()` for both committing and emergency committing.

Voting is done with `ESDS`, whereas `totalBonded()` measures the total amount of `ESD`. Due to this difference, %s were determined as ~150x higher than they should have been for the purpose of the proposal and commitment checks.

This proposal simply changes `totalBonded()` to the correct `totalSupply()` in the affected areas.

## Tracking
Implementation: https://etherscan.io/address/0xd2d6737d3f4Ad0504C669AD9364C4a7318Fb2092
Status: Proposal