### PR TITLE
[Proposal] 7: Supply Change Limit to 3%

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -64,7 +64,7 @@ library Constants {
     uint256 private constant DEBT_RATIO_CAP = 35e16; // 35%
 
     /* Regulator */
-    uint256 private constant SUPPLY_CHANGE_LIMIT = 1e17; // 10%
+    uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
     uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
 
     /* Deployed */

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,9 +31,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // Pool 3
-        _state.provider.pool = address(0xBBDA9B2f267b94147cB5b51653237C2F1EE69054);
-
         // Reward committer
         mintToAccount(msg.sender, Constants.getAdvanceIncentive());
     }

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -27,230 +27,6 @@ describe('Regulator', function () {
     this.dollar = await Dollar.at(await this.regulator.dollar());
   });
 
-  describe('bootstrapping', function () {
-    describe('up regulation', function () {
-      describe('above limit', function () {
-        beforeEach(async function () {
-          await this.regulator.incrementEpochE(); // 1
-          await this.regulator.incrementEpochE(); // 2
-          await this.regulator.incrementTotalBondedE(1000000);
-          await this.regulator.mintToE(this.regulator.address, 1000000);
-        });
-
-        describe('on step', function () {
-          beforeEach(async function () {
-            await this.oracle.set(115, 100, true);
-            this.result = await this.regulator.stepE();
-            this.txHash = this.result.tx;
-          });
-
-          it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
-          });
-
-          it('updates totals', async function () {
-            expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('emits SupplyIncrease event', async function () {
-            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-            expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
-            expect(event.args.price).to.be.bignumber.equal(new BN(110).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
-          });
-        });
-      });
-
-      describe('below limit', function () {
-        beforeEach(async function () {
-          await this.regulator.incrementEpochE(); // 1
-          await this.regulator.incrementEpochE(); // 2
-          await this.regulator.incrementTotalBondedE(1000000);
-          await this.regulator.mintToE(this.regulator.address, 1000000);
-        });
-
-        describe('on step', function () {
-          beforeEach(async function () {
-            await this.oracle.set(105, 100, true);
-            this.result = await this.regulator.stepE();
-            this.txHash = this.result.tx;
-          });
-
-          it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
-          });
-
-          it('updates totals', async function () {
-            expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('emits SupplyIncrease event', async function () {
-            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-            expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
-            expect(event.args.price).to.be.bignumber.equal(new BN(110).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
-          });
-        });
-      });
-    });
-
-    describe('down regulation', function () {
-      describe('under limit', function () {
-        beforeEach(async function () {
-          await this.regulator.incrementEpochE(); // 1
-
-          await this.regulator.incrementTotalBondedE(1000000);
-          await this.regulator.mintToE(this.regulator.address, 1000000);
-
-          await this.regulator.incrementEpochE(); // 2
-
-        });
-
-        describe('on step', function () {
-          beforeEach(async function () {
-            await this.oracle.set(85, 100, true);
-            this.result = await this.regulator.stepE();
-            this.txHash = this.result.tx;
-          });
-
-          it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
-          });
-
-          it('updates totals', async function () {
-            expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('emits SupplyIncrease event', async function () {
-            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-            expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
-            expect(event.args.price).to.be.bignumber.equal(new BN(110).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
-          });
-        });
-      });
-
-      describe('above limit', function () {
-        beforeEach(async function () {
-          await this.regulator.incrementEpochE(); // 1
-
-          await this.regulator.incrementTotalBondedE(1000000);
-          await this.regulator.mintToE(this.regulator.address, 1000000);
-
-          await this.regulator.incrementEpochE(); // 2
-
-        });
-
-        describe('on step', function () {
-          beforeEach(async function () {
-            await this.oracle.set(95, 100, true);
-            this.result = await this.regulator.stepE();
-            this.txHash = this.result.tx;
-          });
-
-          it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
-          });
-
-          it('updates totals', async function () {
-            expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('emits SupplyIncrease event', async function () {
-            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-            expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
-            expect(event.args.price).to.be.bignumber.equal(new BN(110).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
-          });
-        });
-      });
-    });
-
-    describe('neutral regulation', function () {
-      beforeEach(async function () {
-        await this.regulator.incrementEpochE(); // 1
-
-        await this.regulator.incrementTotalBondedE(1000000);
-        await this.regulator.mintToE(this.regulator.address, 1000000);
-
-        await this.regulator.incrementEpochE(); // 2
-      });
-
-      describe('on step', function () {
-        beforeEach(async function () {
-          await this.oracle.set(100, 100, true);
-          this.result = await this.regulator.stepE();
-          this.txHash = this.result.tx;
-        });
-
-        it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
-        });
-
-        it('updates totals', async function () {
-          expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-          expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-        });
-
-        it('emits SupplyIncrease event', async function () {
-          const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-          expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
-          expect(event.args.price).to.be.bignumber.equal(new BN(110).mul(new BN(10).pow(new BN(16))));
-          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
-        });
-      });
-    });
-  });
-
   describe('after bootstrapped', function () {
     beforeEach(async function () {
       await this.regulator.incrementEpochE(); // 1
@@ -272,19 +48,21 @@ describe('Regulator', function () {
         describe('on step', function () {
           beforeEach(async function () {
             await this.oracle.set(115, 100, true);
+            this.expectedReward = 30000;
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
 
           it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(100000));
+            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
           });
 
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 100000));
+            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
             expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
@@ -298,7 +76,7 @@ describe('Regulator', function () {
             expect(event.args.price).to.be.bignumber.equal(new BN(115).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
             expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
+            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward));
           });
         });
       });
@@ -313,20 +91,22 @@ describe('Regulator', function () {
 
         describe('on step', function () {
           beforeEach(async function () {
-            await this.oracle.set(105, 100, true);
+            await this.oracle.set(101, 100, true);
+            this.expectedReward = 10000;
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
 
           it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1050000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 50000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(50000));
+            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
           });
 
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 50000));
+            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
             expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
@@ -337,10 +117,10 @@ describe('Regulator', function () {
             const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
             expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(50000));
+            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward));
           });
         });
       });
@@ -358,7 +138,7 @@ describe('Regulator', function () {
 
         describe('on step', function () {
           beforeEach(async function () {
-            await this.oracle.set(105, 100, true);
+            await this.oracle.set(101, 100, true);
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
@@ -373,7 +153,7 @@ describe('Regulator', function () {
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(55000));
+            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(91000));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
@@ -383,9 +163,9 @@ describe('Regulator', function () {
             const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(45000));
+            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(9000));
             expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
           });
         });
@@ -405,14 +185,16 @@ describe('Regulator', function () {
 
         describe('on step', function () {
           beforeEach(async function () {
-            await this.oracle.set(105, 100, true);
+            await this.oracle.set(101, 100, true);
+            this.expectedReward = 10000;
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
 
           it('mints new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1050000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1050000));
+            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
             expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
@@ -423,15 +205,15 @@ describe('Regulator', function () {
             expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(100000));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(50000));
+            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(this.expectedReward));
           });
 
           it('emits SupplyIncrease event', async function () {
             const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(50000));
+            expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(this.expectedReward));
             expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
             expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
           });
@@ -447,25 +229,27 @@ describe('Regulator', function () {
         await this.regulator.incrementTotalBondedE(1000000);
         await this.regulator.mintToE(this.regulator.address, 1000000);
 
-        await this.regulator.increaseDebtE(new BN(10000));
+        await this.regulator.increaseDebtE(new BN(2000));
       });
 
       describe('on step', function () {
         beforeEach(async function () {
-          await this.oracle.set(105, 100, true);
+          await this.oracle.set(101, 100, true);
+          this.expectedReward = 7980;
+
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1039500));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, 39500));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(39500));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
+          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
         });
 
         it('updates totals', async function () {
           expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 39500));
+          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
           expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
@@ -476,10 +260,10 @@ describe('Regulator', function () {
           const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
           expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-          expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
+          expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
           expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(10000));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(39500));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
+          expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward));
         });
       });
     });
@@ -492,7 +276,7 @@ describe('Regulator', function () {
         await this.regulator.mintToE(this.regulator.address, 1000000);
 
         await this.regulator.increaseDebtE(new BN(100000));
-        await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(10000));
+        await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(2000));
 
         await this.regulator.incrementEpochE(); // 2
 
@@ -500,14 +284,16 @@ describe('Regulator', function () {
 
       describe('on step', function () {
         beforeEach(async function () {
-          await this.oracle.set(105, 100, true);
+          await this.oracle.set(101, 100, true);
+          this.expectedLessDebt = 7000;
+
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1010000));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1010000));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1002000));
+          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1002000));
           expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
           expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
         });
@@ -515,19 +301,19 @@ describe('Regulator', function () {
         it('updates totals', async function () {
           expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-          expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(65000));
+          expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(100000).sub(new BN(this.expectedLessDebt)));
           expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(10000));
-          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(10000));
+          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(2000));
+          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(2000));
         });
 
         it('emits SupplyIncrease event', async function () {
           const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
           expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-          expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
-          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(10000));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(35000));
+          expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
+          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(this.expectedLessDebt));
           expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
         });
       });
@@ -540,8 +326,8 @@ describe('Regulator', function () {
         await this.regulator.incrementTotalBondedE(1000000);
         await this.regulator.mintToE(this.regulator.address, 1000000);
 
-        await this.regulator.increaseDebtE(new BN(10000));
-        await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(10000));
+        await this.regulator.increaseDebtE(new BN(2000));
+        await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(2000));
 
         await this.regulator.incrementEpochE(); // 2
 
@@ -549,34 +335,36 @@ describe('Regulator', function () {
 
       describe('on step', function () {
         beforeEach(async function () {
-          await this.oracle.set(105, 100, true);
+          await this.oracle.set(101, 100, true);
+          this.expectedReward = 7980
+
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1039500));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1010000, 29500));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(29500));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
+          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1002000, this.expectedReward - 2000));
+          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward - 2000));
         });
 
         it('updates totals', async function () {
           expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, 29500));
+          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward - 2000));
           expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(10000));
-          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(10000));
+          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(2000));
+          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(2000));
         });
 
         it('emits SupplyIncrease event', async function () {
           const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
 
           expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-          expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
-          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(10000));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(10000));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(29500));
+          expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
+          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
+          expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward - 2000));
         });
       });
     });
@@ -596,6 +384,8 @@ describe('Regulator', function () {
         describe('on step', function () {
           beforeEach(async function () {
             await this.oracle.set(85, 100, true);
+            this.expectedDebt = 30000;
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
@@ -610,7 +400,7 @@ describe('Regulator', function () {
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(100000));
+            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(this.expectedDebt));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
@@ -621,7 +411,7 @@ describe('Regulator', function () {
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(8));
             expect(event.args.price).to.be.bignumber.equal(new BN(85).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newDebt).to.be.bignumber.equal(new BN(100000));
+            expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
           });
         });
       });
@@ -639,7 +429,9 @@ describe('Regulator', function () {
 
         describe('on step', function () {
           beforeEach(async function () {
-            await this.oracle.set(95, 100, true);
+            await this.oracle.set(99, 100, true);
+            this.expectedDebt = 10000
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
@@ -654,7 +446,7 @@ describe('Regulator', function () {
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(50000));
+            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(this.expectedDebt));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
@@ -664,8 +456,8 @@ describe('Regulator', function () {
             const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyDecrease', {});
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(95).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newDebt).to.be.bignumber.equal(new BN(50000));
+            expect(event.args.price).to.be.bignumber.equal(new BN(99).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
           });
         });
       });
@@ -684,7 +476,9 @@ describe('Regulator', function () {
 
         describe('on step', function () {
           beforeEach(async function () {
-            await this.oracle.set(95, 100, true);
+            await this.oracle.set(99, 100, true);
+            this.expectedDebt = 9000;
+
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
           });
@@ -700,7 +494,7 @@ describe('Regulator', function () {
             it('updates totals', async function () {
               expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(145000));
+              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(100000).add(new BN(this.expectedDebt)));
               expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
@@ -711,8 +505,8 @@ describe('Regulator', function () {
             const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyDecrease', {});
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(95).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newDebt).to.be.bignumber.equal(new BN(45000));
+            expect(event.args.price).to.be.bignumber.equal(new BN(99).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
           });
         });
       });


### PR DESCRIPTION
# Proposal 7: Supply Change Limit to 3%

## Summary
- Reduces Supply Change Limit from `10%` to `3%`.

## Description
#### Supply Change Limit
During a positive or negative regulation, the change in supply is limited by the `SUPPLY_CHANGE_LIMIT`. Currently the limit is set as `10%` of the net supply. This currently limits:
- New supply during expansion to `10%` of current supply.
- Debt issued during contraction to `10%` of net supply (total - debt).
- Debt paid and Redeemable issued while recovering from a contraction period to `10%` of net supply (total - debt).

This change will reduce the `SUPPLY_CHANGE_LIMIT` from `10%` to `3%`.

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Implementation: https://etherscan.io/address/0xdAf2593AaF8EF040E279c806aaB8deDFE534d421
Status: Proposal