### PR TITLE
[Proposal] 8: Improvements to ESD Coupon Redemption

### DIFF
--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -88,11 +88,12 @@ contract Market is Comptroller, Curve {
         return couponAmount;
     }
 
-    function redeemCoupons(uint256 epoch, uint256 couponAmount) external {
-        decrementBalanceOfCoupons(msg.sender, epoch, couponAmount, "Market: Insufficient coupon balance");
+    function redeemCoupons(uint256 couponEpoch, uint256 couponAmount) external {
+        require(epoch().sub(couponEpoch) >= 2, "Market: Too early to redeem");
+        decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
         redeemToAccount(msg.sender, couponAmount);
 
-        emit CouponRedemption(msg.sender, epoch, couponAmount);
+        emit CouponRedemption(msg.sender, couponEpoch, couponAmount);
     }
 
     function approveCoupons(address spender, uint256 amount) external {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -34,6 +34,7 @@ contract Regulator is Comptroller {
         Decimal.D256 memory price = oracleCapture();
 
         if (price.greaterThan(Decimal.one())) {
+            setDebtToZero();
             growSupply(price);
             return;
         }

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -62,6 +62,10 @@ contract Setters is State, Getters {
         _state.balance.debt = _state.balance.debt.sub(amount, reason);
     }
 
+    function setDebtToZero() internal {
+        _state.balance.debt = 0;
+    }
+
     function incrementTotalRedeemable(uint256 amount) internal {
         _state.balance.redeemable = _state.balance.redeemable.add(amount);
     }

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -81,7 +81,7 @@ describe('Regulator', function () {
         });
       });
 
-      describe('(3) - only to bonded', function () {
+      describe('(2) - only to bonded', function () {
         beforeEach(async function () {
           await this.regulator.incrementEpochE(); // 1
           await this.regulator.incrementEpochE(); // 2
@@ -125,59 +125,14 @@ describe('Regulator', function () {
         });
       });
 
-      describe('(2) - only to repay debt', function () {
-        beforeEach(async function () {
-          await this.regulator.incrementEpochE(); // 1
-          await this.regulator.incrementEpochE(); // 2
-
-          await this.regulator.incrementTotalBondedE(1000000);
-          await this.regulator.mintToE(this.regulator.address, 1000000);
-
-          await this.regulator.increaseDebtE(new BN(100000));
-        });
-
-        describe('on step', function () {
-          beforeEach(async function () {
-            await this.oracle.set(101, 100, true);
-            this.result = await this.regulator.stepE();
-            this.txHash = this.result.tx;
-          });
-
-          it('doesnt mint new Dollar tokens', async function () {
-            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('updates totals', async function () {
-            expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-            expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(91000));
-            expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-          });
-
-          it('emits SupplyIncrease event', async function () {
-            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-            expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-            expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
-            expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(9000));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
-          });
-        });
-      });
-
-      describe('(1) - only refresh redeemable debt', function () {
+      describe('(1) - only refresh redeemable', function () {
         beforeEach(async function () {
           await this.regulator.incrementEpochE(); // 1
 
           await this.regulator.incrementTotalBondedE(1000000);
           await this.regulator.mintToE(this.regulator.address, 1000000);
 
+          await this.regulator.increaseDebtE(new BN(2000));
           await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(100000));
 
           await this.regulator.incrementEpochE(); // 2
@@ -221,105 +176,7 @@ describe('Regulator', function () {
       });
     });
 
-    describe('(2 + 3) - repay debt then mint to bonded', function () {
-      beforeEach(async function () {
-        await this.regulator.incrementEpochE(); // 1
-        await this.regulator.incrementEpochE(); // 2
-
-        await this.regulator.incrementTotalBondedE(1000000);
-        await this.regulator.mintToE(this.regulator.address, 1000000);
-
-        await this.regulator.increaseDebtE(new BN(2000));
-      });
-
-      describe('on step', function () {
-        beforeEach(async function () {
-          await this.oracle.set(101, 100, true);
-          this.expectedReward = 7980;
-
-          this.result = await this.regulator.stepE();
-          this.txHash = this.result.tx;
-        });
-
-        it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
-        });
-
-        it('updates totals', async function () {
-          expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
-          expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
-        });
-
-        it('emits SupplyIncrease event', async function () {
-          const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-          expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-          expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
-          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(0));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward));
-        });
-      });
-    });
-
-    describe('(1 + 2) - refresh redeemable then repay debt', function () {
-      beforeEach(async function () {
-        await this.regulator.incrementEpochE(); // 1
-
-        await this.regulator.incrementTotalBondedE(1000000);
-        await this.regulator.mintToE(this.regulator.address, 1000000);
-
-        await this.regulator.increaseDebtE(new BN(100000));
-        await this.regulator.incrementBalanceOfCouponsE(userAddress, 1, new BN(2000));
-
-        await this.regulator.incrementEpochE(); // 2
-
-      });
-
-      describe('on step', function () {
-        beforeEach(async function () {
-          await this.oracle.set(101, 100, true);
-          this.expectedLessDebt = 7000;
-
-          this.result = await this.regulator.stepE();
-          this.txHash = this.result.tx;
-        });
-
-        it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1002000));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1002000));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-          expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
-        });
-
-        it('updates totals', async function () {
-          expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-          expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(100000).sub(new BN(this.expectedLessDebt)));
-          expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(2000));
-          expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(2000));
-        });
-
-        it('emits SupplyIncrease event', async function () {
-          const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyIncrease', {});
-
-          expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
-          expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
-          expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(this.expectedLessDebt));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
-        });
-      });
-    });
-
-    describe('(1 + 2 + 3) - refresh redeemable then repay debt then mint to bonded', function () {
+    describe('(1 + 2) - refresh redeemable then mint to bonded', function () {
       beforeEach(async function () {
         await this.regulator.incrementEpochE(); // 1
 
@@ -336,7 +193,7 @@ describe('Regulator', function () {
       describe('on step', function () {
         beforeEach(async function () {
           await this.oracle.set(101, 100, true);
-          this.expectedReward = 7980
+          this.expectedReward = 10000
 
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
@@ -363,7 +220,7 @@ describe('Regulator', function () {
           expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
           expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
           expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
           expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward - 2000));
         });
       });


### PR DESCRIPTION
# Proposal 8: Improvements to ESD Coupon Redemption

## Summary
This proposal implements part of [EIP-1](https://www.emptyset.xyz/t/eip-1-improvements-to-esd-coupon-redemption/32) based on the accompanying feedback.
- Implements:
  - **Part I**: Wipe debt on first expansion
  - **Scott's Addendum**: Require 2 epoch wait before coupons becomes redeemable
- Does *not* implement:
  - **Part II**: EOA-only advance call.

## Description
Retroactive PR to capture and add tests to the changes introduced in Prop 8, which is our first community ideated, developed, and proposed upgrade.

Credit to: Will Price and Robert Leshner for the EIP, as well as Scott Lewis for important additions, with code from Austin Williams.

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Implementation: https://etherscan.io/address/0x2BB93FBDfA5c9dcdB157b90524978727c871AF3C
Status: Proposal