### PR TITLE
[Proposal] 11: Reduce Governance Thresholds

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -52,7 +52,7 @@ library Constants {
 
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 9;
-    uint256 private constant GOVERNANCE_QUORUM = 33e16; // 33%
+    uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -52,7 +52,7 @@ library Constants {
 
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 9; // 9 epochs
-    uint256 private constant GOVERNANCE_EXPIRATION = 3; // 3 epochs
+    uint256 private constant GOVERNANCE_EXPIRATION = 2; // 2 + 1 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -51,7 +51,8 @@ library Constants {
     uint256 private constant CURRENT_EPOCH_PERIOD = 28800;
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 9;
+    uint256 private constant GOVERNANCE_PERIOD = 9; // 9 epochs
+    uint256 private constant GOVERNANCE_EXPIRATION = 3; // 3 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
@@ -124,6 +125,10 @@ library Constants {
 
     function getGovernancePeriod() internal pure returns (uint256) {
         return GOVERNANCE_PERIOD;
+    }
+
+    function getGovernanceExpiration() internal pure returns (uint256) {
+        return GOVERNANCE_EXPIRATION;
     }
 
     function getGovernanceQuorum() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -53,6 +53,7 @@ library Constants {
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 9;
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
+    uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
@@ -127,6 +128,10 @@ library Constants {
 
     function getGovernanceQuorum() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: GOVERNANCE_QUORUM});
+    }
+
+    function getGovernanceProposalThreshold() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: GOVERNANCE_PROPOSAL_THRESHOLD});
     }
 
     function getGovernanceSuperMajority() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -77,10 +77,6 @@ library Constants {
     address private constant DOLLAR_ADDRESS = address(0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723);
     address private constant PAIR_ADDRESS = address(0x88ff79eB2Bc5850F27315415da8685282C7610F9);
 
-    /* Pool Migration */
-    address private constant LEGACY_POOL_ADDRESS = address(0xdF0Ae5504A48ab9f913F8490fBef1b9333A68e68);
-    uint256 private constant LEGACY_POOL_REWARD = 1e18; // 1 ESD
-
     /**
      * Getters
      */
@@ -187,13 +183,5 @@ library Constants {
 
     function getPairAddress() internal pure returns (address) {
         return PAIR_ADDRESS;
-    }
-
-    function getLegacyPoolAddress() internal pure returns (address) {
-        return LEGACY_POOL_ADDRESS;
-    }
-
-    function getLegacyPoolReward() internal pure returns (uint256) {
-        return LEGACY_POOL_REWARD;
     }
 }

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -57,11 +57,13 @@ contract Comptroller is Setters {
         balanceCheck();
     }
 
-    function increaseDebt(uint256 amount) internal {
+    function increaseDebt(uint256 amount) internal returns (uint256) {
         incrementTotalDebt(amount);
-        resetDebt(Constants.getDebtRatioCap());
+        uint256 lessDebt = resetDebt(Constants.getDebtRatioCap());
 
         balanceCheck();
+
+        return lessDebt > amount ? 0 : amount.sub(lessDebt);
     }
 
     function decreaseDebt(uint256 amount) internal {

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -126,6 +126,14 @@ contract Getters is State {
         return epoch() >= _state.accounts[account].fluidUntil ? Account.Status.Frozen : Account.Status.Fluid;
     }
 
+    function fluidUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].fluidUntil;
+    }
+
+    function lockedUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].lockedUntil;
+    }
+
     function allowanceCoupons(address owner, address spender) public view returns (uint256) {
         return _state.accounts[owner].couponAllowances[spender];
     }

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -100,7 +100,7 @@ contract Govern is Setters, Permission, Upgradeable {
         );
 
         Require.that(
-            epoch() <= endsAfter.add(Constants.getGovernanceExpiration()),
+            epoch() <= endsAfter.add(1).add(Constants.getGovernanceExpiration()),
             FILE,
             "Expired"
         );

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -152,6 +152,6 @@ contract Govern is Setters, Permission, Upgradeable {
         }
 
         Decimal.D256 memory stake = Decimal.ratio(balanceOf(account), totalSupply());
-        return stake.greaterThan(Decimal.ratio(1, 100)); // 1%
+        return stake.greaterThan(Decimal.ratio(5, 1000)); // 0.5%
     }
 }

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -100,6 +100,12 @@ contract Govern is Setters, Permission, Upgradeable {
         );
 
         Require.that(
+            epoch() <= endsAfter.add(Constants.getGovernanceExpiration()),
+            FILE,
+            "Expired"
+        );
+
+        Require.that(
             Decimal.ratio(votesFor(candidate), totalBondedAt(endsAfter)).greaterThan(Constants.getGovernanceQuorum()),
             FILE,
             "Must have quorom"

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -152,6 +152,6 @@ contract Govern is Setters, Permission, Upgradeable {
         }
 
         Decimal.D256 memory stake = Decimal.ratio(balanceOf(account), totalSupply());
-        return stake.greaterThan(Decimal.ratio(5, 1000)); // 0.5%
+        return stake.greaterThan(Constants.getGovernanceProposalThreshold());
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -34,11 +34,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         // Reward committer
         mintToAccount(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
-        mintToAccount(address(0x25Cb5b18A3D6C7cf562dE456ab8368ED577C0173), Constants.getAdvanceIncentive() * 30);
-        mintToAccount(address(0x9541f37c00901E21F1e11f4f90FE8F04E18B7793), Constants.getAdvanceIncentive() * 30);
-        mintToAccount(address(0x8CA440e6e8AD6DbcAbec20Df94DC19047c614a6c), Constants.getAdvanceIncentive() * 10);
-        // New Pool address
-        _state.provider.pool = address(0x4082D11E506e3250009A991061ACd2176077C88f);
+
     }
 
     function advance() external incentivized {
@@ -54,9 +50,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         uint256 incentive = Constants.getAdvanceIncentive();
         mintToAccount(msg.sender, incentive);
         emit Incentivization(msg.sender, incentive);
-
-        // Mint legacy pool reward for migration
-        mintToAccount(Constants.getLegacyPoolAddress(), Constants.getLegacyPoolReward());
 
         _;
     }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -32,12 +32,14 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function initialize() initializer public {
         // Reward committer
-        mintToAccount(msg.sender, Constants.getAdvanceIncentive());
+        incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
 
     }
 
-    function advance() external incentivized {
+    function advance() external {
+        incentivize(msg.sender, Constants.getAdvanceIncentive());
+
         Bonding.step();
         Regulator.step();
         Market.step();
@@ -45,12 +47,8 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         emit Advance(epoch(), block.number, block.timestamp);
     }
 
-    modifier incentivized {
-        // Mint advance reward to sender
-        uint256 incentive = Constants.getAdvanceIncentive();
-        mintToAccount(msg.sender, incentive);
-        emit Incentivization(msg.sender, incentive);
-
-        _;
+    function incentivize(address account, uint256 amount) private {
+        mintToAccount(account, amount);
+        emit Incentivization(account, amount);
     }
 }

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -46,7 +46,7 @@ contract Market is Comptroller, Curve {
 
     function expireCouponsForEpoch(uint256 epoch) private {
         uint256 couponsForEpoch = outstandingCoupons(epoch);
-        (uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded) = (0, 0, 0);
+        (uint256 lessRedeemable, uint256 newBonded) = (0, 0);
 
         eliminateOutstandingCoupons(epoch);
 
@@ -55,10 +55,10 @@ contract Market is Comptroller, Curve {
         if (totalRedeemable > totalCoupons) {
             lessRedeemable = totalRedeemable.sub(totalCoupons);
             burnRedeemable(lessRedeemable);
-            (, lessDebt, newBonded) = increaseSupply(lessRedeemable);
+            (, newBonded) = increaseSupply(lessRedeemable);
         }
 
-        emit CouponExpiration(epoch, couponsForEpoch, lessRedeemable, lessDebt, newBonded);
+        emit CouponExpiration(epoch, couponsForEpoch, lessRedeemable, 0, newBonded);
     }
 
     function couponPremium(uint256 amount) public view returns (uint256) {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -49,9 +49,9 @@ contract Regulator is Comptroller {
     function shrinkSupply(Decimal.D256 memory price) private {
         Decimal.D256 memory delta = limit(Decimal.one().sub(price), price);
         uint256 newDebt = delta.mul(totalNet()).asUint256();
-        increaseDebt(newDebt);
+        uint256 cappedNewDebt = increaseDebt(newDebt);
 
-        emit SupplyDecrease(epoch(), price.value, newDebt);
+        emit SupplyDecrease(epoch(), price.value, cappedNewDebt);
         return;
     }
 

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -62,10 +62,6 @@ contract Setters is State, Getters {
         _state.balance.debt = _state.balance.debt.sub(amount, reason);
     }
 
-    function setDebtToZero() internal {
-        _state.balance.debt = 0;
-    }
-
     function incrementTotalRedeemable(uint256 amount) internal {
         _state.balance.redeemable = _state.balance.redeemable.add(amount);
     }

--- a/protocol/test/dao/Govern.test.js
+++ b/protocol/test/dao/Govern.test.js
@@ -9,6 +9,7 @@ const MockImplA = contract.fromArtifact('MockImplA');
 const MockImplB = contract.fromArtifact('MockImplB');
 
 const VOTE_PERIOD = 9;
+const EXPIRATION = 3;
 const EMERGENCY_COMMIT_PERIOD = 6;
 
 const UNDECIDED = new BN(0);
@@ -334,6 +335,21 @@ describe('Govern', function () {
           account: userAddress,
           candidate: this.implB.address,
         });
+      });
+    });
+
+    describe('expired', function () {
+      beforeEach(async function () {
+        await this.govern.vote(this.implB.address, REJECT, {from: userAddress});
+        await this.govern.vote(this.implB.address, APPROVE, {from: userAddress2});
+        for(let i = 0; i < VOTE_PERIOD + EXPIRATION; i++) {
+          await this.govern.snapshotTotalBondedE();
+          await this.govern.incrementEpochE();
+        }
+      });
+
+      it('reverts', async function () {
+        await expectRevert(this.govern.commit(this.implB.address, {from: userAddress}), "Govern: Expired");
       });
     });
 

--- a/protocol/test/dao/Govern.test.js
+++ b/protocol/test/dao/Govern.test.js
@@ -256,8 +256,8 @@ describe('Govern', function () {
 
   describe('commit', function () {
     beforeEach(async function () {
-      await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(2500));
-      await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(4000));
+      await this.govern.incrementBalanceOfE(userAddress, INITIAL_STAKE_MULTIPLE.muln(2000));
+      await this.govern.incrementBalanceOfE(userAddress2, INITIAL_STAKE_MULTIPLE.muln(4500));
       await this.govern.incrementBalanceOfE(userAddress3, INITIAL_STAKE_MULTIPLE.muln(3500));
       await this.govern.incrementTotalBondedE(10000);
     });

--- a/protocol/test/dao/Market.test.js
+++ b/protocol/test/dao/Market.test.js
@@ -506,7 +506,7 @@ describe('Market', function () {
         });
       });
 
-      describe('reclaimed some debt', function () {
+      describe('with some debt', function () {
         this.timeout(30000);
 
         beforeEach(async function () {
@@ -533,12 +533,13 @@ describe('Market', function () {
 
           expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
           expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(54662));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(47277));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
+          expect(event.args.lessRedeemable).to.be.bignumber.equal(new BN(47277));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
+          expect(event.args.newBonded).to.be.bignumber.equal(new BN(47277));
         });
       });
 
-      describe('reclaimed all debt and some bonded', function () {
+      describe('with more reclaimed than debt', function () {
         this.timeout(30000);
 
         beforeEach(async function () {
@@ -565,8 +566,9 @@ describe('Market', function () {
 
           expect(event.args.epoch).to.be.bignumber.equal(new BN(2));
           expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(53377));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(20000));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(28446));
+          expect(event.args.lessRedeemable).to.be.bignumber.equal(new BN(48446));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
+          expect(event.args.newBonded).to.be.bignumber.equal(new BN(48446));
         });
       });
     });

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -7,7 +7,6 @@ const MockRegulator = contract.fromArtifact('MockRegulator');
 const MockSettableOracle = contract.fromArtifact('MockSettableOracle');
 const Dollar = contract.fromArtifact('Dollar');
 
-const LEGACY_POOL_ADDRESS = "0xdF0Ae5504A48ab9f913F8490fBef1b9333A68e68";
 const POOL_REWARD_PERCENT = 20;
 
 function lessPoolIncentive(baseAmount, newAmount) {
@@ -154,7 +153,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward - this.expectedRewardLP)));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -172,7 +170,7 @@ describe('Regulator', function () {
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
             expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(this.expectedRewardCoupons));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
+            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
             expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO));
           });
         });
@@ -224,7 +222,7 @@ describe('Regulator', function () {
           expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
           expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
           expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
-          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
+          expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
           expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward - 2000));
         });
       });
@@ -260,7 +258,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward - this.expectedRewardLP)));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -278,7 +275,7 @@ describe('Regulator', function () {
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
             expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(this.expectedRewardCoupons));
-            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
+            expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
             expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO));
           });
         });
@@ -309,7 +306,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -355,7 +351,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -402,7 +397,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -450,7 +444,6 @@ describe('Regulator', function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-            expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
           });
 
           it('updates totals', async function () {
@@ -497,7 +490,6 @@ describe('Regulator', function () {
           expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
           expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
           expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-          expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
         });
 
         it('updates totals', async function () {
@@ -539,7 +531,6 @@ describe('Regulator', function () {
           expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
           expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
           expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
-          expect(await this.dollar.balanceOf(LEGACY_POOL_ADDRESS)).to.be.bignumber.equal(new BN(0));
         });
 
         it('updates totals', async function () {

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -419,7 +419,8 @@ describe('Regulator', function () {
           });
         });
       });
-      describe('with debt over default but under coupon limit', function () {
+
+      describe('with debt over limit', function () {
         beforeEach(async function () {
           await this.regulator.incrementEpochE(); // 1
 
@@ -462,6 +463,102 @@ describe('Regulator', function () {
 
             expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
             expect(event.args.price).to.be.bignumber.equal(new BN(95).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
+          });
+        });
+      });
+
+      describe('with debt some capped', function () {
+        beforeEach(async function () {
+          await this.regulator.incrementEpochE(); // 1
+
+          await this.regulator.incrementTotalBondedE(1000000);
+          await this.regulator.mintToE(this.regulator.address, 1000000);
+
+          await this.regulator.increaseDebtE(new BN(345000));
+
+          await this.regulator.incrementEpochE(); // 2
+        });
+
+        describe('on step', function () {
+          beforeEach(async function () {
+            await this.oracle.set(99, 100, true);
+            this.expectedDebt = 5000;
+
+            this.result = await this.regulator.stepE();
+            this.txHash = this.result.tx;
+          });
+
+          it('doesnt mint new Dollar tokens', async function () {
+            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
+            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
+          });
+
+          it('updates totals', async function () {
+            it('updates totals', async function () {
+              expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
+              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(345000).add(new BN(this.expectedDebt)));
+              expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
+            });
+          });
+
+          it('emits SupplyDecrease event', async function () {
+            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyDecrease', {});
+
+            expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
+            expect(event.args.price).to.be.bignumber.equal(new BN(99).mul(new BN(10).pow(new BN(16))));
+            expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
+          });
+        });
+      });
+
+      describe('with debt all capped', function () {
+        beforeEach(async function () {
+          await this.regulator.incrementEpochE(); // 1
+
+          await this.regulator.incrementTotalBondedE(1000000);
+          await this.regulator.mintToE(this.regulator.address, 1000000);
+
+          await this.regulator.increaseDebtE(new BN(350000));
+
+          await this.regulator.incrementEpochE(); // 2
+        });
+
+        describe('on step', function () {
+          beforeEach(async function () {
+            await this.oracle.set(99, 100, true);
+            this.expectedDebt = 0;
+
+            this.result = await this.regulator.stepE();
+            this.txHash = this.result.tx;
+          });
+
+          it('doesnt mint new Dollar tokens', async function () {
+            expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000));
+            expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(0));
+          });
+
+          it('updates totals', async function () {
+            it('updates totals', async function () {
+              expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
+              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(350000).add(new BN(this.expectedDebt)));
+              expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
+              expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));
+            });
+          });
+
+          it('emits SupplyDecrease event', async function () {
+            const event = await expectEvent.inTransaction(this.txHash, MockRegulator, 'SupplyDecrease', {});
+
+            expect(event.args.epoch).to.be.bignumber.equal(new BN(7));
+            expect(event.args.price).to.be.bignumber.equal(new BN(99).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newDebt).to.be.bignumber.equal(new BN(this.expectedDebt));
           });
         });

--- a/protocol/test/dao/State.test.js
+++ b/protocol/test/dao/State.test.js
@@ -422,6 +422,7 @@ describe('State', function () {
     describe('before called', function () {
       it('is frozen', async function () {
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(0));
+        expect(await this.setters.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(0));
       });
     });
 
@@ -432,6 +433,7 @@ describe('State', function () {
 
       it('is fluid', async function () {
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(1));
+        expect(await this.setters.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(15));
       });
     });
 
@@ -443,6 +445,7 @@ describe('State', function () {
 
       it('is fluid', async function () {
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(1));
+        expect(await this.setters.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(15));
       });
     });
 
@@ -456,6 +459,7 @@ describe('State', function () {
 
       it('is frozen', async function () {
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(0));
+        expect(await this.setters.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(15));
       });
     });
   });
@@ -949,6 +953,7 @@ describe('State', function () {
       it('should have locked user', async function () {
         expect(await this.setters.isNominated(candidate)).to.be.equal(true);
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(2));
+        expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(8));
       });
     });
 
@@ -968,6 +973,7 @@ describe('State', function () {
       it('should have unlocked user', async function () {
         expect(await this.setters.isNominated(candidate)).to.be.equal(true);
         expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(0));
+        expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(8));
       });
     });
 
@@ -994,6 +1000,7 @@ describe('State', function () {
           expect(await this.setters.isNominated(candidate)).to.be.equal(true);
           expect(await this.setters.isNominated(ownerAddress)).to.be.equal(true);
           expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(2));
+          expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(10));
         });
       });
 
@@ -1011,6 +1018,7 @@ describe('State', function () {
         it('should have unlocked user', async function () {
           expect(await this.setters.isNominated(candidate)).to.be.equal(true);
           expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(0));
+          expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(10));
         });
       });
     });
@@ -1037,6 +1045,7 @@ describe('State', function () {
           expect(await this.setters.isNominated(candidate)).to.be.equal(true);
           expect(await this.setters.isNominated(ownerAddress)).to.be.equal(true);
           expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(2));
+          expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(10));
         });
       });
 
@@ -1054,6 +1063,7 @@ describe('State', function () {
         it('should have unlocked user', async function () {
           expect(await this.setters.isNominated(candidate)).to.be.equal(true);
           expect(await this.setters.statusOf(userAddress)).to.be.bignumber.equal(new BN(0));
+          expect(await this.setters.lockedUntil(userAddress)).to.be.bignumber.equal(new BN(10));
         });
       });
     });


### PR DESCRIPTION
# Proposal 11: Reduce Governance Thresholds

## Summary
- Implements [EIP-8](https://www.emptyset.xyz/t/eip-8-quorum-and-proposal-threshold-reductions/85)
- Several QoL improvements

## Description
#### EIP-8
- Lowers the governance proposal threshold from `1%` to `0.5%`.
- Lowers the governance quorum threshold from `33%` to `20%`. 

#### Quality of life improvements
- Removes `Pool 1` migration reward payout.
- Refactors proposal threshold into `Constants.sol`.
- Fully decouples debt repayment from the `increaseSupply` method.
- Adds getters for `lockedUntil` and `fluidUntil` user data.
- Standardizes events for incentivization rewards.

#### Safety
- Adds `3` epoch expiration for approved proposals. This ensures that if governance rules change in the future, we don't accidentally enable an old proposal to be committed.

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Status: Pre-proposal