### PR TITLE
[Proposal] 12: Add Treasury

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -73,11 +73,13 @@ library Constants {
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
     uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
+    uint256 private constant TREASURY_RATIO = 250; // 2.5%
 
     /* Deployed */
     address private constant DAO_ADDRESS = address(0x443D2f2755DB5942601fa062Cc248aAA153313D3);
     address private constant DOLLAR_ADDRESS = address(0x36F3FD68E7325a35EB768F1AedaAe9EA0689d723);
     address private constant PAIR_ADDRESS = address(0x88ff79eB2Bc5850F27315415da8685282C7610F9);
+    address private constant TREASURY_ADDRESS = address(0x460661bd4A5364A3ABCc9cfc4a8cE7038d05Ea22);
 
     /**
      * Getters
@@ -179,6 +181,10 @@ library Constants {
         return ORACLE_POOL_RATIO;
     }
 
+    function getTreasuryRatio() internal pure returns (uint256) {
+        return TREASURY_RATIO;
+    }
+
     function getChainId() internal pure returns (uint256) {
         return CHAIN_ID;
     }
@@ -193,5 +199,9 @@ library Constants {
 
     function getPairAddress() internal pure returns (address) {
         return PAIR_ADDRESS;
+    }
+
+    function getTreasuryAddress() internal pure returns (address) {
+        return TREASURY_ADDRESS;
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,6 +31,8 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
+        // Bootstrap Treasury
+        incentivize(Constants.getTreasuryAddress(), 5e23);
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards

--- a/protocol/test/dao/Market.test.js
+++ b/protocol/test/dao/Market.test.js
@@ -433,7 +433,7 @@ describe('Market', function () {
         expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(103703));
         expect(event.args.lessRedeemable).to.be.bignumber.equal(new BN(100000));
         expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-        expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
+        expect(event.args.newBonded).to.be.bignumber.equal(new BN(22500));
       });
     });
 

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -8,13 +8,19 @@ const MockSettableOracle = contract.fromArtifact('MockSettableOracle');
 const Dollar = contract.fromArtifact('Dollar');
 
 const POOL_REWARD_PERCENT = 20;
+const TREASURY_REWARD_BIPS = 250;
+const TREASURY_ADDRESS = '0x460661bd4A5364A3ABCc9cfc4a8cE7038d05Ea22';
 
-function lessPoolIncentive(baseAmount, newAmount) {
-  return new BN(baseAmount + newAmount - poolIncentive(newAmount));
+function lessPoolAndTreasuryIncentive(baseAmount, newAmount) {
+  return new BN(baseAmount + newAmount - poolIncentive(newAmount) - treasuryIncentive(newAmount));
 }
 
 function poolIncentive(newAmount) {
   return new BN(newAmount * POOL_REWARD_PERCENT / 100);
+}
+
+function treasuryIncentive(newAmount) {
+  return new BN(newAmount * TREASURY_REWARD_BIPS / 10000);
 }
 
 describe('Regulator', function () {
@@ -55,13 +61,14 @@ describe('Regulator', function () {
 
           it('mints new Dollar tokens', async function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
+            expect(await this.dollar.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
           });
 
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
             expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
@@ -99,13 +106,15 @@ describe('Regulator', function () {
 
           it('mints new Dollar tokens', async function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(poolIncentive(this.expectedReward));
+            expect(await this.dollar.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(treasuryIncentive(this.expectedReward));
+
           });
 
           it('updates totals', async function () {
             expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward));
+            expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolAndTreasuryIncentive(1000000, this.expectedReward));
             expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
             expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
@@ -141,9 +150,10 @@ describe('Regulator', function () {
           beforeEach(async function () {
             await this.oracle.set(101, 100, true);
             this.expectedReward = 10000;
-            this.expectedRewardCoupons = 8000;
+            this.expectedRewardCoupons = 7750;
             this.expectedRewardDAO = 0;
             this.expectedRewardLP = 2000;
+            this.expectedRewardTreasury = 250;
 
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
@@ -151,8 +161,9 @@ describe('Regulator', function () {
 
           it('mints new Dollar tokens', async function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward - this.expectedRewardLP)));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedRewardCoupons)));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
+            expect(await this.dollar.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
           });
 
           it('updates totals', async function () {
@@ -171,7 +182,7 @@ describe('Regulator', function () {
             expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(this.expectedRewardCoupons));
             expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO));
+            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO + this.expectedRewardTreasury));
           });
         });
       });
@@ -194,22 +205,25 @@ describe('Regulator', function () {
       describe('on step', function () {
         beforeEach(async function () {
           await this.oracle.set(101, 100, true);
-          this.expectedReward = 10000;
-          this.poolReward = 400;
+          this.bondedReward = 5750;
+          this.newRedeemable = 2000;
+          this.poolReward = 2000;
+          this.treasuryReward = 250;
 
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
         });
 
         it('mints new Dollar tokens', async function () {
-          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(lessPoolIncentive(1002000, this.expectedReward - 2000).sub(new BN(this.poolReward)));
-          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.poolReward).add(poolIncentive(this.expectedReward - 2000)));
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1010000));
+          expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000 + this.newRedeemable + this.bondedReward));
+          expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.poolReward));
+          expect(await this.dollar.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.treasuryReward));
         });
 
         it('updates totals', async function () {
           expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
-          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(lessPoolIncentive(1000000, this.expectedReward - 2000).sub(new BN(this.poolReward)));
+          expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000 + this.bondedReward));
           expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
           expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(2000));
@@ -223,7 +237,7 @@ describe('Regulator', function () {
           expect(event.args.price).to.be.bignumber.equal(new BN(101).mul(new BN(10).pow(new BN(16))));
           expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(2000));
           expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
-          expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedReward - 2000));
+          expect(event.args.newBonded).to.be.bignumber.equal(new BN(8000));
         });
       });
     });
@@ -241,14 +255,14 @@ describe('Regulator', function () {
           await this.regulator.incrementEpochE(); // 2
         });
 
-
         describe('on step', function () {
           beforeEach(async function () {
             await this.oracle.set(105, 100, true);
             this.expectedReward = 50000;
-            this.expectedRewardCoupons = 40000;
+            this.expectedRewardCoupons = 38750;
             this.expectedRewardDAO = 0;
             this.expectedRewardLP = 10000;
+            this.expectedRewardTreasury = 1250;
 
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
@@ -256,8 +270,9 @@ describe('Regulator', function () {
 
           it('mints new Dollar tokens', async function () {
             expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward)));
-            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedReward - this.expectedRewardLP)));
+            expect(await this.dollar.balanceOf(this.regulator.address)).to.be.bignumber.equal(new BN(1000000).add(new BN(this.expectedRewardCoupons)));
             expect(await this.dollar.balanceOf(poolAddress)).to.be.bignumber.equal(new BN(this.expectedRewardLP));
+            expect(await this.dollar.balanceOf(TREASURY_ADDRESS)).to.be.bignumber.equal(new BN(this.expectedRewardTreasury));
           });
 
           it('updates totals', async function () {
@@ -276,7 +291,7 @@ describe('Regulator', function () {
             expect(event.args.price).to.be.bignumber.equal(new BN(105).mul(new BN(10).pow(new BN(16))));
             expect(event.args.newRedeemable).to.be.bignumber.equal(new BN(this.expectedRewardCoupons));
             expect(event.args.lessDebt).to.be.bignumber.equal(new BN(2000));
-            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO));
+            expect(event.args.newBonded).to.be.bignumber.equal(new BN(this.expectedRewardLP + this.expectedRewardDAO + this.expectedRewardTreasury));
           });
         });
     });


### PR DESCRIPTION
# Proposal 12: Add Treasury

## Summary
- Implements [EIP-10](https://www.emptyset.xyz/t/eip-10-protocol-funding/90)

## Description
#### EIP-10
EIP-10 creates a community fund treasury for incentivizing future work on the ESD protocol. More info here: [EIP-10](https://www.emptyset.xyz/t/eip-10-protocol-funding/90).

The treasury is implemented as a gnosis safe with 7 signers deployer here: [0x460661bd4A5364A3ABCc9cfc4a8cE7038d05Ea22](https://etherscan.io/address/0x460661bd4A5364A3ABCc9cfc4a8cE7038d05Ea22)

- Rewards `500,000 ESD` to treasury on commit.
- Adds a 2.5% expansion reward for treasury
   - 77.5/2.5/20 DAO/Treasury/LP during regular expansion
   - 77.5/2.5/20 Coupon/Treasury/LP during coupon expansion

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Status: Proposed
Implementation: [0xFDad22E653C103Ef4310e4D68E88c8Dc4705F2D1](https://etherscan.io/address/0xFDad22E653C103Ef4310e4D68E88c8Dc4705F2D1)