### PR TITLE
[Proposal 13]: Update Coupon Curve

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -67,7 +67,7 @@ library Constants {
 
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 90;
-    uint256 private constant DEBT_RATIO_CAP = 35e16; // 35%
+    uint256 private constant DEBT_RATIO_CAP = 15e16; // 15%
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%

--- a/protocol/contracts/dao/Curve.sol
+++ b/protocol/contracts/dao/Curve.sol
@@ -61,14 +61,14 @@ contract Curve {
         return curveMean(debtRatioEnd, debtRatio);
     }
 
-    // 1/(3(1-R)^2)-1/3
+    // 1/((1-R)^2)-1
     function curve(Decimal.D256 memory debtRatio) private pure returns (Decimal.D256 memory) {
         return Decimal.one().div(
-            Decimal.from(3).mul((Decimal.one().sub(debtRatio)).pow(2))
-        ).sub(Decimal.ratio(1, 3));
+            (Decimal.one().sub(debtRatio)).pow(2)
+        ).sub(Decimal.one());
     }
 
-    // 1/(3(1-R)(1-R'))-1/3
+    // 1/((1-R)(1-R'))-1
     function curveMean(
         Decimal.D256 memory lower,
         Decimal.D256 memory upper
@@ -78,7 +78,7 @@ contract Curve {
         }
 
         return Decimal.one().div(
-            Decimal.from(3).mul(Decimal.one().sub(upper)).mul(Decimal.one().sub(lower))
-        ).sub(Decimal.ratio(1, 3));
+            (Decimal.one().sub(upper)).mul(Decimal.one().sub(lower))
+        ).sub(Decimal.one());
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,12 +31,14 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // Bootstrap Treasury
-        incentivize(Constants.getTreasuryAddress(), 5e23);
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
+        incentivize(address(0x739e3aD76c6BBe301e6e358a1f8326F31ab89335), 2500e18);
 
+        // Cut the debt to 40% to ease any potential premium shock
+        uint256 decreaseAmount = totalDebt().mul(3).div(5);
+        decreaseDebt(decreaseAmount);
     }
 
     function advance() external {

--- a/protocol/test/dao/Comptroller.test.js
+++ b/protocol/test/dao/Comptroller.test.js
@@ -228,23 +228,23 @@ describe('Comptroller', function () {
 
     describe('multiple calls', function () {
       beforeEach(async function () {
-        await this.comptroller.increaseDebtE(new BN(100));
-        await this.comptroller.increaseDebtE(new BN(200));
+        await this.comptroller.increaseDebtE(new BN(10));
+        await this.comptroller.increaseDebtE(new BN(20));
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(300));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(30));
       });
     });
 
-    describe('increase past supply', function () {
+    describe('increase past cap', function () {
       beforeEach(async function () {
         await this.comptroller.increaseDebtE(new BN(100));
         await this.comptroller.increaseDebtE(new BN(300));
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(350));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(150));
       });
     });
 
@@ -255,7 +255,7 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(350));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(150));
       });
     });
   });
@@ -263,7 +263,7 @@ describe('Comptroller', function () {
   describe('decreaseDebt', function () {
     beforeEach(async function () {
       await this.comptroller.mintToE(userAddress, new BN(1000));
-      await this.comptroller.increaseDebtE(new BN(350))
+      await this.comptroller.increaseDebtE(new BN(150))
     });
 
     describe('on single call', function () {
@@ -272,24 +272,24 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(250));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(50));
       });
     });
 
     describe('multiple calls', function () {
       beforeEach(async function () {
-        await this.comptroller.decreaseDebtE(new BN(100));
-        await this.comptroller.decreaseDebtE(new BN(200));
+        await this.comptroller.decreaseDebtE(new BN(10));
+        await this.comptroller.decreaseDebtE(new BN(20));
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(50));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(120));
       });
     });
 
     describe('decrease past supply', function () {
       it('reverts', async function () {
-        await expectRevert(this.comptroller.decreaseDebtE(new BN(400)), "not enough debt");
+        await expectRevert(this.comptroller.decreaseDebtE(new BN(200)), "not enough debt");
       });
     });
   });
@@ -305,36 +305,36 @@ describe('Comptroller', function () {
     describe('excess debt', function () {
       beforeEach(async function () {
         await this.comptroller.increaseDebtE(new BN(5000));
-        await this.comptroller.resetDebtE(new BN(30));
+        await this.comptroller.resetDebtE(new BN(10));
       });
 
       it('decreases debt', async function () {
         expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(3000));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(1000));
       });
     });
 
     describe('equal debt', function () {
       beforeEach(async function () {
         await this.comptroller.increaseDebtE(new BN(3000));
-        await this.comptroller.resetDebtE(new BN(30));
-      });
-
-      it('debt unchanged', async function () {
-        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(3000));
-      });
-    });
-
-    describe('less debt', function () {
-      beforeEach(async function () {
-        await this.comptroller.increaseDebtE(new BN(1000));
-        await this.comptroller.resetDebtE(new BN(30));
+        await this.comptroller.resetDebtE(new BN(10));
       });
 
       it('debt unchanged', async function () {
         expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
         expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(1000));
+      });
+    });
+
+    describe('less debt', function () {
+      beforeEach(async function () {
+        await this.comptroller.increaseDebtE(new BN(500));
+        await this.comptroller.resetDebtE(new BN(10));
+      });
+
+      it('debt unchanged', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(10000));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(500));
       });
     });
   });

--- a/protocol/test/dao/Curve.test.js
+++ b/protocol/test/dao/Curve.test.js
@@ -42,38 +42,38 @@ describe('Curve', function () {
     });
   });
 
-  describe('10-100-10: 0.0037037 - not enough to round to unit', function () {
+  describe('5-100-5: 0.26315 - not enough to round to unit', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100, 10, 10)).to.be.bignumber.equal(new BN(0));
+      expect(await this.curve.calculateCouponsE(100, 5, 5)).to.be.bignumber.equal(new BN(0));
     });
   });
 
-  describe('100000-10000-10000: 370.37 - should add 370', function () {
+  describe('100000-5000-5000: 263.15 - should add 263', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 10000, 10000)).to.be.bignumber.equal(new BN(370));
+      expect(await this.curve.calculateCouponsE(100000, 5000, 5000)).to.be.bignumber.equal(new BN(263));
     });
   });
 
-  describe('100000-10000-5000: 288.066 - should add 288', function () {
+  describe('100000-10000-5000: 864.19 - should add 864', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 10000, 5000)).to.be.bignumber.equal(new BN(288));
+      expect(await this.curve.calculateCouponsE(100000, 10000, 5000)).to.be.bignumber.equal(new BN(864));
     });
   });
 
-  describe('100000-70000-10000: 0.455621 (above threshold) - should add 4556', function () {
+  describe('100000-70000-10000: 0.384083 (above threshold) - should add 3840', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 70000, 10000)).to.be.bignumber.equal(new BN(4556));
+      expect(await this.curve.calculateCouponsE(100000, 70000, 10000)).to.be.bignumber.equal(new BN(3840));
     });
   });
 
-  /* 60000/100000 -> 10000/50000
-   * 0.6 -> 0.1
-   * 0.6 - 0.35 (above threshold) + 0.2 - 0.35 (below threshold)
-   * (0.25 * 0.455621 + 0.15 * 0.307692) / 0.4 = 0.400148
+  /* 60000/100000 -> 5000/45000
+   * 0.6 -> 1/9
+   * 0.6 - 0.15 (above threshold) + 1/9 - 0.15 (below threshold)
+   * (0.45 * 0.384083 + (0.15-1/9) * 0.323529) / (0.6-1/9) = 0.379266
    */
-  describe('100000-60000-50000: 6636.44 (above and below threshold) - should add 6636', function () {
+  describe('100000-60000-55000: 20859 (above and below threshold) - should add 20859', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 60000, 50000)).to.be.bignumber.equal(new BN(20007));
+      expect(await this.curve.calculateCouponsE(100000, 60000, 55000)).to.be.bignumber.equal(new BN(20859));
     });
   });
 });

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -490,7 +490,7 @@ describe('Regulator', function () {
           await this.regulator.incrementTotalBondedE(1000000);
           await this.regulator.mintToE(this.regulator.address, 1000000);
 
-          await this.regulator.increaseDebtE(new BN(345000));
+          await this.regulator.increaseDebtE(new BN(145000));
 
           await this.regulator.incrementEpochE(); // 2
         });
@@ -514,7 +514,7 @@ describe('Regulator', function () {
             it('updates totals', async function () {
               expect(await this.regulator.totalStaged()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalBonded()).to.be.bignumber.equal(new BN(1000000));
-              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(345000).add(new BN(this.expectedDebt)));
+              expect(await this.regulator.totalDebt()).to.be.bignumber.equal(new BN(145000).add(new BN(this.expectedDebt)));
               expect(await this.regulator.totalSupply()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalCoupons()).to.be.bignumber.equal(new BN(0));
               expect(await this.regulator.totalRedeemable()).to.be.bignumber.equal(new BN(0));


### PR DESCRIPTION
# [Proposal 13]: Update Coupon Curve

## Summary
- Implements [EIP-9](https://www.emptyset.xyz/t/eip-9-coupon-premium-curve-evolution/87)

## Description
#### EIP-9
The goal of EIP-9 is to steepen the coupon premium curve in order to create a more responsive coupon process and also to reduce the overall dilution from contraction periods.

- Steepens the coupon premium curve from: `1/(3(1-R)^2)-1/3` to `1/((1-R)^2)-1`. 
- Lowers debt cap from `35%` to `15%`, corresponding to `45.6%` and `38.4%` premiums respectively.
- One time 60% reduction in protocol `debt` upon commit to avoid and premium jumps.

## Rewards
- Rewards `committer` with `100 ESD`
- Rewards @Austin-Williams with `2500 ESD` for initial implementation.

## Tracking
Status: Pre-proposal
Implementation: 