### PR TITLE
[Proposal] 14: Increase Debt Cap to 20%

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -67,7 +67,7 @@ library Constants {
 
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 90;
-    uint256 private constant DEBT_RATIO_CAP = 15e16; // 15%
+    uint256 private constant DEBT_RATIO_CAP = 20e16; // 20%
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -34,11 +34,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
-        incentivize(address(0x739e3aD76c6BBe301e6e358a1f8326F31ab89335), 2500e18);
 
-        // Cut the debt to 40% to ease any potential premium shock
-        uint256 decreaseAmount = totalDebt().mul(3).div(5);
-        decreaseDebt(decreaseAmount);
     }
 
     function advance() external {

--- a/protocol/test/dao/Comptroller.test.js
+++ b/protocol/test/dao/Comptroller.test.js
@@ -244,7 +244,7 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(150));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(200));
       });
     });
 
@@ -255,7 +255,7 @@ describe('Comptroller', function () {
       });
 
       it('updates total debt', async function () {
-        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(150));
+        expect(await this.comptroller.totalDebt()).to.be.bignumber.equal(new BN(200));
       });
     });
   });

--- a/protocol/test/dao/Curve.test.js
+++ b/protocol/test/dao/Curve.test.js
@@ -60,20 +60,20 @@ describe('Curve', function () {
     });
   });
 
-  describe('100000-70000-10000: 0.384083 (above threshold) - should add 3840', function () {
+  describe('100000-70000-10000: 0.5625 (above threshold) - should add 5625', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 70000, 10000)).to.be.bignumber.equal(new BN(3840));
+      expect(await this.curve.calculateCouponsE(100000, 70000, 10000)).to.be.bignumber.equal(new BN(5625));
     });
   });
 
   /* 60000/100000 -> 5000/45000
    * 0.6 -> 1/9
-   * 0.6 - 0.15 (above threshold) + 1/9 - 0.15 (below threshold)
-   * (0.45 * 0.384083 + (0.15-1/9) * 0.323529) / (0.6-1/9) = 0.379266
+   * 0.6 - 0.2 (above threshold) + 1/9 - 0.2 (below threshold)
+   * (0.4 * 0.5625 + (0.2-1/9) * 0.40625) / (0.6-1/9) = 0.5340909
    */
-  describe('100000-60000-55000: 20859 (above and below threshold) - should add 20859', function () {
+  describe('100000-60000-55000: 29374 (above and below threshold) - should add 29374', function () {
     it('returns correct amount', async function () {
-      expect(await this.curve.calculateCouponsE(100000, 60000, 55000)).to.be.bignumber.equal(new BN(20859));
+      expect(await this.curve.calculateCouponsE(100000, 60000, 55000)).to.be.bignumber.equal(new BN(29374));
     });
   });
 });

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -490,7 +490,7 @@ describe('Regulator', function () {
           await this.regulator.incrementTotalBondedE(1000000);
           await this.regulator.mintToE(this.regulator.address, 1000000);
 
-          await this.regulator.increaseDebtE(new BN(145000));
+          await this.regulator.increaseDebtE(new BN(195000));
 
           await this.regulator.incrementEpochE(); // 2
         });


### PR DESCRIPTION
# [Proposal 14]: Increase Debt Cap to 20%

## Summary
- Implements Debt Cap part of [EIP-9](https://www.emptyset.xyz/t/eip-9-coupon-premium-curve-evolution/87)

## Description
#### EIP-9
The goal of EIP-9 is to steepen the coupon premium curve in order to create a more responsive coupon process and also to reduce the overall dilution from contraction periods.

- Raises debt cap from `15%` to `20%`, corresponding to `38.4%` and `56.2%` premiums respectively.

## Rewards
- Rewards `committer` with `100 ESD`

## Tracking
Status: Pre-proposal
Implementation: [0xf7752941cb46785a51b23859deb36fdf1e18af4d](https://etherscan.io/address/0xf7752941cb46785a51b23859deb36fdf1e18af4d)