### PR TITLE
[Proposal] ?: Increase Treasury Rewards & Establish Liquidity Incentive Fund

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -72,8 +72,8 @@ library Constants {
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
-    uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
-    uint256 private constant TREASURY_RATIO = 250; // 2.5%
+    uint256 private constant ORACLE_POOL_RATIO = 1250; // 12.5%
+    uint256 private constant TREASURY_RATIO = 1000; // 10%
 
     /* Deployed */
     address private constant DAO_ADDRESS = address(0x443D2f2755DB5942601fa062Cc248aAA153313D3);

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -74,7 +74,7 @@ contract Comptroller is Setters {
 
     function increaseSupply(uint256 newSupply) internal returns (uint256, uint256) {
         // 0-a. Pay out to Pool
-        uint256 poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(100);
+        uint256 poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(10000);
         mintToPool(poolReward);
 
         // 0-b. Pay out to Treasury

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -36,7 +36,8 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
-
+        incentivize(address(0xC85170886A7F34e1365E2aA04486ae8F1106F783), 1000e18);
+        incentivize(address(0xD8bCa431135F1b906c545834C0740f240F2BC2A7), 1500e18);
     }
 
     function advance() external {

--- a/protocol/test/dao/Regulator.test.js
+++ b/protocol/test/dao/Regulator.test.js
@@ -7,8 +7,8 @@ const MockRegulator = contract.fromArtifact('MockRegulator');
 const MockSettableOracle = contract.fromArtifact('MockSettableOracle');
 const Dollar = contract.fromArtifact('Dollar');
 
-const POOL_REWARD_PERCENT = 20;
-const TREASURY_REWARD_BIPS = 250;
+const POOL_REWARD_BIPS = 1250;
+const TREASURY_REWARD_BIPS = 1000;
 const TREASURY_ADDRESS = '0x460661bd4A5364A3ABCc9cfc4a8cE7038d05Ea22';
 
 function lessPoolAndTreasuryIncentive(baseAmount, newAmount) {
@@ -16,7 +16,7 @@ function lessPoolAndTreasuryIncentive(baseAmount, newAmount) {
 }
 
 function poolIncentive(newAmount) {
-  return new BN(newAmount * POOL_REWARD_PERCENT / 100);
+  return new BN(newAmount * POOL_REWARD_BIPS / 10000);
 }
 
 function treasuryIncentive(newAmount) {
@@ -152,8 +152,8 @@ describe('Regulator', function () {
             this.expectedReward = 10000;
             this.expectedRewardCoupons = 7750;
             this.expectedRewardDAO = 0;
-            this.expectedRewardLP = 2000;
-            this.expectedRewardTreasury = 250;
+            this.expectedRewardLP = 1250;
+            this.expectedRewardTreasury = 1000;
 
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;
@@ -207,8 +207,8 @@ describe('Regulator', function () {
           await this.oracle.set(101, 100, true);
           this.bondedReward = 5750;
           this.newRedeemable = 2000;
-          this.poolReward = 2000;
-          this.treasuryReward = 250;
+          this.poolReward = 1250;
+          this.treasuryReward = 1000;
 
           this.result = await this.regulator.stepE();
           this.txHash = this.result.tx;
@@ -261,8 +261,8 @@ describe('Regulator', function () {
             this.expectedReward = 50000;
             this.expectedRewardCoupons = 38750;
             this.expectedRewardDAO = 0;
-            this.expectedRewardLP = 10000;
-            this.expectedRewardTreasury = 1250;
+            this.expectedRewardLP = 6250;
+            this.expectedRewardTreasury = 5000;
 
             this.result = await this.regulator.stepE();
             this.txHash = this.result.tx;


### PR DESCRIPTION
# [Proposal] ?: Increase Treasury Rewards & Establish Liquidity Incentive Fund

## Summary

- Implements [EIP-11](https://www.emptyset.xyz/t/eip-11-increase-treasury-rewards-establish-liquidity-incentive-fund/100)

## Description

**EIP-11**

Change the supply expansion distribution to:

- When No Coupons: `77.5% / 12.5% / 10%` (DAO/LP/Treasury)
- When Coupons Active: `77.5% / 12.5% / 10% `(Coupons/LP/Treasury)

Allocate `75%` of treasury to liquidity mining reward programs. Many of which can be performed in conjunction with strategic partners that are currently helping with future or current integrations (i.e. Curve, Sushiswap, Bancor, Saffron, CREAM, etc.).

**Parameters**

- Update `ORACLE_POOL_RATIO` to `12.5%`
- Update `TREASURY_RATIO` to `10%`

## Rewards

- Rewards `proposer` with `1000 ESD`
- Rewards `dev` with `1500 ESD`
- Rewards `committer` with `100 ESD`

## Tracking

Status: Pre-proposal
Implementation:  