### PR TITLE
[Proposal] 15: Split Coupon Underlying

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -55,11 +55,11 @@ library Constants {
     uint256 private constant GOVERNANCE_EXPIRATION = 2; // 2 + 1 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
-    uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
+    uint256 private constant GOVERNANCE_SUPER_MAJORITY = 40e16; // 40%
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 1e20; // 100 ESD
+    uint256 private constant ADVANCE_INCENTIVE = 1e21; // 1000 ESD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 15; // 15 epochs fluid
 
     /* Pool */

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -43,9 +43,12 @@ contract Comptroller is Setters {
         balanceCheck();
     }
 
-    function redeemToAccount(address account, uint256 amount) internal {
-        dollar().transfer(account, amount);
-        decrementTotalRedeemable(amount, "Comptroller: not enough redeemable balance");
+    function redeemToAccount(address account, uint256 amount, uint256 couponAmount) internal {
+        dollar().mint(account, amount);
+        if (couponAmount != 0) {
+            dollar().transfer(account, couponAmount);
+            decrementTotalRedeemable(couponAmount, "Comptroller: not enough redeemable balance");
+        }
 
         balanceCheck();
     }

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -87,6 +87,10 @@ contract Getters is State {
         return _state.balance.redeemable;
     }
 
+    function totalCouponUnderlying() public view returns (uint256) {
+        return _state16.couponUnderlying;
+    }
+
     function totalCoupons() public view returns (uint256) {
         return _state.balance.coupons;
     }
@@ -116,6 +120,10 @@ contract Getters is State {
             return 0;
         }
         return _state.accounts[account].coupons[epoch];
+    }
+
+    function balanceOfCouponUnderlying(address account, uint256 epoch) public view returns (uint256) {
+        return _state16.couponUnderlyingByAccount[account][epoch];
     }
 
     function statusOf(address account) public view returns (Account.Status) {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -34,7 +34,10 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
+        incentivize(0x6a7217C003aAb08543657B404aC9988a844cBa4B, 5000e18);
 
+        // Reset debt to zero for new coupon mechanic
+        _state.balance.debt = 0;
     }
 
     function advance() external {

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -29,7 +29,7 @@ contract Market is Comptroller, Curve {
 
     event CouponExpiration(uint256 indexed epoch, uint256 couponsExpired, uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded);
     event CouponPurchase(address indexed account, uint256 indexed epoch, uint256 dollarAmount, uint256 couponAmount);
-    event CouponRedemption(address indexed account, uint256 indexed epoch, uint256 couponAmount);
+    event CouponRedemption(address indexed account, uint256 indexed epoch, uint256 amount, uint256 couponAmount);
     event CouponTransfer(address indexed from, address indexed to, uint256 indexed epoch, uint256 value);
     event CouponApproval(address indexed owner, address indexed spender, uint256 value);
 
@@ -52,6 +52,7 @@ contract Market is Comptroller, Curve {
 
         uint256 totalRedeemable = totalRedeemable();
         uint256 totalCoupons = totalCoupons();
+
         if (totalRedeemable > totalCoupons) {
             lessRedeemable = totalRedeemable.sub(totalCoupons);
             burnRedeemable(lessRedeemable);
@@ -65,35 +66,64 @@ contract Market is Comptroller, Curve {
         return calculateCouponPremium(dollar().totalSupply(), totalDebt(), amount);
     }
 
-    function purchaseCoupons(uint256 dollarAmount) external returns (uint256) {
+    function migrateCoupons(uint256 couponEpoch) external {
+        uint256 balanceOfCoupons = balanceOfCoupons(msg.sender, couponEpoch);
+        require(balanceOfCoupons > 0, "Market: No coupons");
+        require(balanceOfCouponUnderlying(msg.sender, couponEpoch) == 0, "Market: Already migrated");
+
+        uint256 couponUnderlying = balanceOfCoupons.div(2);
+
+        incrementBalanceOfCouponUnderlying(msg.sender, couponEpoch, couponUnderlying);
+        decrementBalanceOfCoupons(msg.sender, couponEpoch, couponUnderlying, "Market: Insufficient coupon balance");
+
+        emit CouponRedemption(msg.sender, couponEpoch, 0, couponUnderlying);
+        emit CouponPurchase(msg.sender, couponEpoch, couponUnderlying, 0);
+    }
+
+    function purchaseCoupons(uint256 amount) external returns (uint256) {
         Require.that(
-            dollarAmount > 0,
+            amount > 0,
             FILE,
             "Must purchase non-zero amount"
         );
 
         Require.that(
-            totalDebt() >= dollarAmount,
+            totalDebt() >= amount,
             FILE,
             "Not enough debt"
         );
 
         uint256 epoch = epoch();
-        uint256 couponAmount = dollarAmount.add(couponPremium(dollarAmount));
-        burnFromAccount(msg.sender, dollarAmount);
+        uint256 couponAmount = couponPremium(amount);
         incrementBalanceOfCoupons(msg.sender, epoch, couponAmount);
+        incrementBalanceOfCouponUnderlying(msg.sender, epoch, amount);
 
-        emit CouponPurchase(msg.sender, epoch, dollarAmount, couponAmount);
+        burnFromAccount(msg.sender, amount);
+
+        emit CouponPurchase(msg.sender, epoch, amount, couponAmount);
 
         return couponAmount;
     }
 
-    function redeemCoupons(uint256 couponEpoch, uint256 couponAmount) external {
+    // @notice: logic overview
+    // 1) Coupons just purchased will fail at 2 epoch check.
+    // 2) Valid coupons without sufficient redeemable will fail at redeemToAccount.
+    // 3) Expired coupons will result in zero couponAmount, passing decrementBalanceOfCoupons
+    //    and redeemToAccount to return underlying only.
+    // 4) Expired coupons with future redeemable will still result in zero couponAmount,
+    //    allowing only underlying to be redeemed.
+    function redeemCoupons(uint256 couponEpoch, uint256 amount) external {
         require(epoch().sub(couponEpoch) >= 2, "Market: Too early to redeem");
-        decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
-        redeemToAccount(msg.sender, couponAmount);
+        require(amount != 0, "Market: Amount too low");
 
-        emit CouponRedemption(msg.sender, couponEpoch, couponAmount);
+        uint256 couponAmount = balanceOfCoupons(msg.sender, couponEpoch)
+            .mul(amount).div(balanceOfCouponUnderlying(msg.sender, couponEpoch), "Market: No underlying");
+
+        decrementBalanceOfCouponUnderlying(msg.sender, couponEpoch, amount, "Market: Insufficient coupon underlying balance");
+        if (couponAmount != 0) decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
+        redeemToAccount(msg.sender, amount, couponAmount);
+
+        emit CouponRedemption(msg.sender, couponEpoch, amount, couponAmount);
     }
 
     function approveCoupons(address spender, uint256 amount) external {
@@ -108,8 +138,14 @@ contract Market is Comptroller, Curve {
         require(sender != address(0), "Market: Coupon transfer from the zero address");
         require(recipient != address(0), "Market: Coupon transfer to the zero address");
 
-        decrementBalanceOfCoupons(sender, epoch, amount, "Market: Insufficient coupon balance");
-        incrementBalanceOfCoupons(recipient, epoch, amount);
+        uint256 couponAmount = balanceOfCoupons(sender, epoch)
+            .mul(amount).div(balanceOfCouponUnderlying(sender, epoch), "Market: No underlying");
+
+        decrementBalanceOfCouponUnderlying(sender, epoch, amount, "Market: Insufficient coupon underlying balance");
+        incrementBalanceOfCouponUnderlying(recipient, epoch, amount);
+
+        decrementBalanceOfCoupons(sender, epoch, couponAmount, "Market: Insufficient coupon balance");
+        incrementBalanceOfCoupons(recipient, epoch, couponAmount);
 
         if (msg.sender != sender && allowanceCoupons(sender, msg.sender) != uint256(-1)) {
             decrementAllowanceCoupons(sender, msg.sender, amount, "Market: Insufficient coupon approval");

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -104,10 +104,20 @@ contract Setters is State, Getters {
         _state.balance.coupons = _state.balance.coupons.add(amount);
     }
 
+    function incrementBalanceOfCouponUnderlying(address account, uint256 epoch, uint256 amount) internal {
+        _state16.couponUnderlyingByAccount[account][epoch] = _state16.couponUnderlyingByAccount[account][epoch].add(amount);
+        _state16.couponUnderlying = _state16.couponUnderlying.add(amount);
+    }
+
     function decrementBalanceOfCoupons(address account, uint256 epoch, uint256 amount, string memory reason) internal {
         _state.accounts[account].coupons[epoch] = _state.accounts[account].coupons[epoch].sub(amount, reason);
         _state.epochs[epoch].coupons.outstanding = _state.epochs[epoch].coupons.outstanding.sub(amount, reason);
         _state.balance.coupons = _state.balance.coupons.sub(amount, reason);
+    }
+
+    function decrementBalanceOfCouponUnderlying(address account, uint256 epoch, uint256 amount, string memory reason) internal {
+        _state16.couponUnderlyingByAccount[account][epoch] = _state16.couponUnderlyingByAccount[account][epoch].sub(amount, reason);
+        _state16.couponUnderlying = _state16.couponUnderlying.sub(amount, reason);
     }
 
     function unfreeze(address account) internal {

--- a/protocol/contracts/dao/State.sol
+++ b/protocol/contracts/dao/State.sol
@@ -100,8 +100,16 @@ contract Storage {
         mapping(uint256 => Epoch.State) epochs;
         mapping(address => Candidate.State) candidates;
     }
+
+    struct State16 {
+        mapping(address => mapping(uint256 => uint256)) couponUnderlyingByAccount;
+        uint256 couponUnderlying;
+    }
 }
 
 contract State {
     Storage.State _state;
+
+    // EIP-16
+    Storage.State16 _state16;
 }

--- a/protocol/contracts/mock/MockComptroller.sol
+++ b/protocol/contracts/mock/MockComptroller.sol
@@ -35,8 +35,8 @@ contract MockComptroller is Comptroller, MockState {
         super.burnFromAccount(account, amount);
     }
 
-    function redeemToAccountE(address account, uint256 amount) external {
-        super.redeemToAccount(account, amount);
+    function redeemToAccountE(address account, uint256 amount, uint256 couponAmount) external {
+        super.redeemToAccount(account, amount, couponAmount);
     }
 
     function burnRedeemableE(uint256 amount) external {

--- a/protocol/contracts/mock/MockState.sol
+++ b/protocol/contracts/mock/MockState.sol
@@ -78,8 +78,16 @@ contract MockState is Setters {
         super.incrementBalanceOfCoupons(account, epoch, amount);
     }
 
+    function incrementBalanceOfCouponUnderlyingE(address account, uint256 epoch, uint256 amount) external {
+        super.incrementBalanceOfCouponUnderlying(account, epoch, amount);
+    }
+
     function decrementBalanceOfCouponsE(address account, uint256 epoch, uint256 amount, string calldata reason) external {
         super.decrementBalanceOfCoupons(account, epoch, amount, reason);
+    }
+
+    function decrementBalanceOfCouponUnderlyingE(address account, uint256 epoch, uint256 amount, string calldata reason) external {
+        super.decrementBalanceOfCouponUnderlying(account, epoch, amount, reason);
     }
 
     function unfreezeE(address account) external {

--- a/protocol/test/dao/Comptroller.test.js
+++ b/protocol/test/dao/Comptroller.test.js
@@ -165,7 +165,7 @@ describe('Comptroller', function () {
 
     describe('on single call', function () {
       beforeEach(async function () {
-        await this.comptroller.redeemToAccountE(userAddress, new BN(100));
+        await this.comptroller.redeemToAccountE(userAddress, new BN(0), new BN(100));
       });
 
       it('doesnt mint new Dollar tokens', async function () {
@@ -181,8 +181,8 @@ describe('Comptroller', function () {
 
     describe('multiple calls', function () {
       beforeEach(async function () {
-        await this.comptroller.redeemToAccountE(userAddress, new BN(100));
-        await this.comptroller.redeemToAccountE(userAddress, new BN(200));
+        await this.comptroller.redeemToAccountE(userAddress, new BN(0), new BN(100));
+        await this.comptroller.redeemToAccountE(userAddress, new BN(0), new BN(200));
       });
 
       it('doesnt mint new Dollar tokens', async function () {
@@ -206,7 +206,39 @@ describe('Comptroller', function () {
       });
 
       it('reverts', async function () {
-        await expectRevert(this.comptroller.redeemToAccountE(userAddress, new BN(400)), "not enough redeemable");
+        await expectRevert(this.comptroller.redeemToAccountE(userAddress, new BN(0), new BN(400)), "not enough redeemable");
+      });
+    });
+
+    describe('with base amount', function () {
+      beforeEach(async function () {
+        await this.comptroller.redeemToAccountE(userAddress, new BN(1000), new BN(100));
+      });
+
+      it('doesnt mint new Dollar tokens', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1300));
+        expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(200));
+        expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(1100));
+      });
+
+      it('updates total redeemable', async function () {
+        expect(await this.comptroller.totalRedeemable()).to.be.bignumber.equal(new BN(200));
+      });
+    });
+
+    describe('only base amount', function () {
+      beforeEach(async function () {
+        await this.comptroller.redeemToAccountE(userAddress, new BN(1000), new BN(0));
+      });
+
+      it('doesnt mint new Dollar tokens', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1300));
+        expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(300));
+        expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(1000));
+      });
+
+      it('updates total redeemable', async function () {
+        expect(await this.comptroller.totalRedeemable()).to.be.bignumber.equal(new BN(300));
       });
     });
   });

--- a/protocol/test/dao/Govern.test.js
+++ b/protocol/test/dao/Govern.test.js
@@ -405,9 +405,9 @@ describe('Govern', function () {
 
     describe('ended with not enough approve votes', function () {
       beforeEach(async function () {
-        await this.govern.vote(this.implB.address, APPROVE, {from: userAddress});
-        await this.govern.vote(this.implB.address, APPROVE, {from: userAddress3});
-        await this.govern.vote(this.implB.address, REJECT, {from: userAddress2});
+        await this.govern.vote(this.implB.address, REJECT, {from: userAddress});
+        await this.govern.vote(this.implB.address, REJECT, {from: userAddress3});
+        await this.govern.vote(this.implB.address, APPROVE, {from: userAddress2});
 
         const epoch = await this.govern.epoch();
         await this.govern.setEpochTime(epoch + EMERGENCY_COMMIT_PERIOD);

--- a/protocol/test/dao/State.test.js
+++ b/protocol/test/dao/State.test.js
@@ -332,6 +332,25 @@ describe('State', function () {
     });
   });
 
+  describe('incrementBalanceOfCouponUnderlying', function () {
+    const epoch = 1;
+
+    describe('when called', function () {
+      beforeEach('call', async function () {
+        await this.setters.incrementBalanceOfCouponUnderlyingE(userAddress, epoch, 100);
+        await this.setters.incrementBalanceOfCouponUnderlyingE(userAddress, epoch, 100);
+      });
+
+      it('increments balance of coupons for user during epoch', async function () {
+        expect(await this.setters.balanceOfCouponUnderlying(userAddress, epoch)).to.be.bignumber.equal(new BN(200));
+      });
+
+      it('increments total outstanding coupons', async function () {
+        expect(await this.setters.totalCouponUnderlying()).to.be.bignumber.equal(new BN(200));
+      });
+    });
+  });
+
   describe('decrementBalanceOfCoupons', function () {
     const epoch = 1;
 
@@ -362,7 +381,39 @@ describe('State', function () {
 
       it('reverts', async function () {
         await expectRevert(
-          this.setters.decrementBalanceOfCouponsE(200, epoch, "decrementBalanceOfCouponsE"),
+          this.setters.decrementBalanceOfCouponsE(userAddress, 200, epoch, "decrementBalanceOfCouponsE"),
+          "decrementBalanceOfCoupons");
+      });
+    });
+  });
+
+  describe('decrementBalanceOfCouponUnderlying', function () {
+    const epoch = 1;
+
+    describe('when called', function () {
+      beforeEach('call', async function () {
+        await this.setters.incrementBalanceOfCouponUnderlyingE(userAddress, epoch, 500);
+        await this.setters.decrementBalanceOfCouponUnderlyingE(userAddress, epoch, 100, "decrementBalanceOfCouponsE - 1");
+        await this.setters.decrementBalanceOfCouponUnderlyingE(userAddress, epoch, 100, "decrementBalanceOfCouponsE - 2");
+      });
+
+      it('decrements balance of coupons for user during epoch', async function () {
+        expect(await this.setters.balanceOfCouponUnderlying(userAddress, epoch)).to.be.bignumber.equal(new BN(300));
+      });
+
+      it('decrements total outstanding coupons', async function () {
+        expect(await this.setters.totalCouponUnderlying()).to.be.bignumber.equal(new BN(300));
+      });
+    });
+
+    describe('when called erroneously', function () {
+      beforeEach('call', async function () {
+        await this.setters.incrementBalanceOfCouponUnderlyingE(userAddress, epoch, 100);
+      });
+
+      it('reverts', async function () {
+        await expectRevert(
+          this.setters.decrementBalanceOfCouponUnderlyingE(userAddress, 200, epoch, "decrementBalanceOfCouponsE"),
           "decrementBalanceOfCouponsE");
       });
     });


### PR DESCRIPTION
# [Proposal 15]: Split Coupon Underlying

## Summary
- Implements [EIP-16](https://www.emptyset.xyz/t/eip-16-split-coupons-into-1-deposit-2-yield-so-that-expiration-only-applies-to-the-2-yield-1-deposit-is-returned-at-expiration/181)

## Description
### EIP-16
EIP-16 aims to significantly reduce the risk of coupons by splitting their principle with their premium reward, treating them differently upon expiration.

#### Expiration Logic
- Underlying (principle) is locked until either:
  1. the premium can be paid out of the redeemable pool or
  2. the coupon has expired
- Expired coupons no longer have the ability to claim their premium reward, but can claim their underlying.

#### Economic Specification
- *Locked* ESD is burned on coupon purchase and minted on underlying redemption so that it is programmatically discluded from total supply.
- Redeemable ESD is only needed to cover the premium reward, principle is simply minted fresh.

#### Migration
A new `migrateCoupons` method is exposed for current coupon holders. This allows current coupon holders to do a one-time migration (per-epoch) to split their coupons `50/50` between underlying and premium. We chose `50%` as it is strictly better from a risk perspective than currently outstanding coupons, but it still worse than  a post-EIP-16 purchase, so there isn't an opportunity to game purchases ahead of this proposal.

Debt will be reset to `0` since this will significantly effect the risk profile of coupons, and we can't accurately predict how this will shift the market premium.

### QoL Improvements
- Reduces the emergency commit quorum from `66%` to `40%` inline with the previous `33%` to `20%` quorum reduction.
- Increases advance reward from `100 ESD` to `1000 ESD` to counteract rising ETH and gas prices.

## Rewards
- Rewards `committer` with `1000 ESD`
- Rewards `@sabretooth` with `5000 ESD`

## Tracking
Status: Proposal
Implementation: [0x9ac39b3e72f3bc07520355a9be5398656c8bc514](https://etherscan.io/address/0x9ac39b3e72f3bc07520355a9be5398656c8bc514#code)