### PR TITLE
[Proposal] 16: Pro-Rated Premium

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -68,6 +68,7 @@ library Constants {
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 90;
     uint256 private constant DEBT_RATIO_CAP = 20e16; // 20%
+    uint256 private constant COUPON_PRORATED_START = 420; // epoch 420
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
@@ -167,6 +168,10 @@ library Constants {
 
     function getDebtRatioCap() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: DEBT_RATIO_CAP});
+    }
+
+    function getCouponProratedStart() internal pure returns (uint256) {
+        return COUPON_PRORATED_START;
     }
 
     function getSupplyChangeLimit() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -99,6 +99,14 @@ contract Getters is State {
         return dollar().totalSupply().sub(totalDebt());
     }
 
+    function eraStatus() public view returns (Era.Status) {
+        return _state18.era.status;
+    }
+
+    function eraStart() public view returns (uint256) {
+        return _state18.era.start;
+    }
+
     /**
      * Account
      */

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -34,10 +34,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         // Reward committer
         incentivize(msg.sender, Constants.getAdvanceIncentive());
         // Dev rewards
-        incentivize(0x6a7217C003aAb08543657B404aC9988a844cBa4B, 5000e18);
 
-        // Reset debt to zero for new coupon mechanic
-        _state.balance.debt = 0;
     }
 
     function advance() external {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -34,11 +34,13 @@ contract Regulator is Comptroller {
         Decimal.D256 memory price = oracleCapture();
 
         if (price.greaterThan(Decimal.one())) {
+            if (eraStatus() == Era.Status.CONTRACTION) updateEra(Era.Status.EXPANSION);
             growSupply(price);
             return;
         }
 
         if (price.lessThan(Decimal.one())) {
+            if (eraStatus() == Era.Status.EXPANSION) updateEra(Era.Status.CONTRACTION);
             shrinkSupply(price);
             return;
         }

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -70,6 +70,11 @@ contract Setters is State, Getters {
         _state.balance.redeemable = _state.balance.redeemable.sub(amount, reason);
     }
 
+    function updateEra(Era.Status status) internal {
+        _state18.era.status = status;
+        _state18.era.start = epoch();
+    }
+
     /**
      * Account
      */

--- a/protocol/contracts/dao/State.sol
+++ b/protocol/contracts/dao/State.sol
@@ -75,6 +75,18 @@ contract Candidate {
     }
 }
 
+contract Era {
+    enum Status {
+        EXPANSION,
+        CONTRACTION
+    }
+
+    struct State {
+        Status status;
+        uint256 start;
+    }
+}
+
 contract Storage {
     struct Provider {
         IDollar dollar;
@@ -105,6 +117,10 @@ contract Storage {
         mapping(address => mapping(uint256 => uint256)) couponUnderlyingByAccount;
         uint256 couponUnderlying;
     }
+
+    struct State18 {
+        Era.State era;
+    }
 }
 
 contract State {
@@ -112,4 +128,7 @@ contract State {
 
     // EIP-16
     Storage.State16 _state16;
+
+    // EIP-18
+    Storage.State18 _state18;
 }

--- a/protocol/contracts/mock/MockMarket.sol
+++ b/protocol/contracts/mock/MockMarket.sol
@@ -22,9 +22,19 @@ import "./MockState.sol";
 import "./MockComptroller.sol";
 
 contract MockMarket is MockState, MockComptroller, Market {
+    uint256 private _couponProratedStart;
+
     constructor(address pool) MockComptroller(pool) public { }
 
     function stepE() external {
         Market.step();
+    }
+
+    function set(uint256 newCouponProratedStart) external {
+        _couponProratedStart = newCouponProratedStart;
+    }
+
+    function couponProratedStart() internal view returns (uint256) {
+        return _couponProratedStart;
     }
 }

--- a/protocol/contracts/mock/MockState.sol
+++ b/protocol/contracts/mock/MockState.sol
@@ -54,6 +54,10 @@ contract MockState is Setters {
         super.decrementTotalRedeemable(amount, reason);
     }
 
+    function updateEraE(Era.Status status) external {
+        super.updateEra(status);
+    }
+
     /**
      * Account
      */

--- a/protocol/test/dao/Market.test.js
+++ b/protocol/test/dao/Market.test.js
@@ -35,6 +35,10 @@ function premiumMean(start, end) {
   return 1.0 / ((1.0 - start) * (1.0 - end)) - 1.0
 }
 
+function prorated(coupons, epochs) {
+  return Math.floor(coupons * epochs / 90);
+}
+
 describe('Market', function () {
   const [ ownerAddress, userAddress, poolAddress ] = accounts;
 
@@ -235,8 +239,10 @@ describe('Market', function () {
     });
   });
 
-  describe('redeemCoupons', function () {
+  describe('redeemCoupons - legacy', function () {
     beforeEach(async function () {
+      await this.market.set(500);
+
       await this.market.incrementTotalDebtE(100000);
       await this.market.purchaseCoupons(100000, {from: userAddress});
       await this.market.mintToE(this.market.address, 100000);
@@ -324,6 +330,157 @@ describe('Market', function () {
           expect(await this.market.totalCoupons()).to.be.bignumber.closeTo(new BN(this.couponAmount - this.redeemedAmount), new BN(1));
           expect(await this.market.totalDebt()).to.be.bignumber.equal(new BN(0));
           expect(await this.market.totalRedeemable()).to.be.bignumber.closeTo(new BN(this.couponAmount - this.redeemedAmount), new BN(1));
+        });
+
+        it('emits CouponRedemption event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockMarket, 'CouponRedemption', {
+            account: userAddress,
+          });
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(50000));
+          expect(event.args.couponAmount).to.be.bignumber.equal(new BN(this.couponAmount / 2));
+        });
+      });
+    });
+
+    describe('after expired', function () {
+      this.timeout(30000);
+
+      beforeEach(async function () {
+        await this.market.mintToE(this.market.address, 100000);
+        await this.market.incrementTotalBondedE(100000);
+
+        for (let i = 0; i < 90; i++) {
+          await this.market.incrementEpochE();
+        }
+        await this.market.stepE();
+
+        this.result = await this.market.redeemCoupons(1, this.couponUnderlying, {from: userAddress});
+        this.txHash = this.result.tx;
+      });
+
+      it('updates user balances', async function () {
+        expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(900000 + this.couponUnderlying));
+        expect(await this.market.balanceOfCoupons(userAddress, 1)).to.be.bignumber.equal(new BN(0));
+        expect(await this.market.balanceOfCouponUnderlying(userAddress, 1)).to.be.bignumber.equal(new BN(0));
+      });
+
+      it('updates dao balances', async function () {
+        let extraBalance = 100000 - this.couponAmount;
+        let redeemableReturned = Math.floor(this.couponAmount * 0.775);
+        expect(await this.dollar.balanceOf(this.market.address)).to.be.bignumber.closeTo(new BN(100000 + extraBalance + redeemableReturned), new BN(1));
+        expect(await this.market.totalCoupons()).to.be.bignumber.equal(new BN(0));
+        expect(await this.market.totalCouponUnderlying()).to.be.bignumber.equal(new BN(0));
+        expect(await this.market.totalDebt()).to.be.bignumber.equal(new BN(0));
+        expect(await this.market.totalRedeemable()).to.be.bignumber.equal(new BN(0));
+      });
+
+      it('emits CouponRedemption event', async function () {
+        const event = await expectEvent.inTransaction(this.txHash, MockMarket, 'CouponRedemption', {
+          account: userAddress,
+        });
+
+        expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+        expect(event.args.amount).to.be.bignumber.equal(new BN(this.couponUnderlying));
+        expect(event.args.couponAmount).to.be.bignumber.equal(new BN(0));
+      });
+    });
+  });
+
+  describe('redeemCoupons - prorated', function () {
+    beforeEach(async function () {
+      await this.market.incrementTotalDebtE(100000);
+      await this.market.purchaseCoupons(100000, {from: userAddress});
+      await this.market.mintToE(this.market.address, 100000);
+
+      this.couponUnderlying = 100000;
+      this.couponAmount = premium(1000000, 100000, 100000);
+
+      const coupons = (await this.market.balanceOfCoupons(userAddress, 1)).toString();
+      const underlying = (await this.market.balanceOfCouponUnderlying(userAddress, 1)).toString();
+
+      await this.market.incrementTotalRedeemableE(this.couponAmount);
+    });
+
+    describe('before redeemable', function () {
+      describe('same epoch', function () {
+        it('reverts', async function () {
+          await expectRevert(this.market.redeemCoupons(1, this.couponUnderlying, {from: userAddress}), "Market: Too early to redeem");
+        });
+      });
+
+      describe('next epoch', function () {
+        it('reverts', async function () {
+          await this.market.incrementEpochE();
+          await expectRevert(this.market.redeemCoupons(1, this.couponUnderlying, {from: userAddress}), "Market: Too early to redeem");
+        });
+      });
+    });
+
+    describe('after redeemable', function () {
+      beforeEach(async function () {
+        await this.market.incrementEpochE();
+        await this.market.incrementEpochE();
+        await this.market.updateEraE(0); // expansion
+      });
+
+      describe('not enough coupon balance', function () {
+        it('reverts', async function () {
+          await expectRevert(this.market.redeemCoupons(1, this.couponUnderlying + 1, {from: userAddress}), "Market: Insufficient coupon underlying balance");
+        });
+      });
+
+      describe('on single call', function () {
+        beforeEach(async function () {
+          this.result = await this.market.redeemCoupons(1, this.couponUnderlying, {from: userAddress});
+          this.txHash = this.result.tx;
+        });
+
+        it('updates user balances', async function () {
+          expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(900000 + this.couponUnderlying + prorated(this.couponAmount, 1)));
+          expect(await this.market.balanceOfCoupons(userAddress, 1)).to.be.bignumber.equal(new BN(0));
+          expect(await this.market.balanceOfCouponUnderlying(userAddress, 1)).to.be.bignumber.equal(new BN(0));
+        });
+
+        it('updates dao balances', async function () {
+          expect(await this.dollar.balanceOf(this.market.address)).to.be.bignumber.equal(new BN(100000 - prorated(this.couponAmount, 1)));
+          expect(await this.market.totalCoupons()).to.be.bignumber.equal(new BN(0));
+          expect(await this.market.totalCouponUnderlying()).to.be.bignumber.equal(new BN(0));
+          expect(await this.market.totalDebt()).to.be.bignumber.equal(new BN(0));
+          expect(await this.market.totalRedeemable()).to.be.bignumber.equal(new BN(this.couponAmount - prorated(this.couponAmount, 1)));
+        });
+
+        it('emits CouponRedemption event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockMarket, 'CouponRedemption', {
+            account: userAddress,
+          });
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(this.couponUnderlying));
+          expect(event.args.couponAmount).to.be.bignumber.equal(new BN(this.couponAmount));
+        });
+      });
+
+      describe('multiple calls', function () {
+        beforeEach(async function () {
+          this.result = await this.market.redeemCoupons(1, 30000, {from: userAddress});
+          this.result = await this.market.redeemCoupons(1, 50000, {from: userAddress});
+          this.txHash = this.result.tx;
+          this.redeemedAmount = (this.couponAmount) * 8 / 10;
+          this.redeemedTotal = (this.couponUnderlying + prorated(this.couponAmount, 1)) * 8 / 10;
+        });
+
+        it('updates user balances', async function () {
+          expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(900000 + this.redeemedTotal));
+          expect(await this.market.balanceOfCoupons(userAddress, 1)).to.be.bignumber.closeTo(new BN(this.couponAmount - this.redeemedAmount), new BN(1));
+        });
+
+        it('updates dao balances', async function () {
+          expect(await this.dollar.balanceOf(this.market.address)).to.be.bignumber.closeTo(new BN(100000 - prorated(this.redeemedAmount, 1)), new BN(1));
+          expect(await this.market.totalCoupons()).to.be.bignumber.closeTo(new BN(this.couponAmount - this.redeemedAmount), new BN(1));
+          expect(await this.market.totalDebt()).to.be.bignumber.equal(new BN(0));
+          expect(await this.market.totalRedeemable()).to.be.bignumber.closeTo(new BN(this.couponAmount - prorated(this.redeemedAmount, 1)), new BN(1));
         });
 
         it('emits CouponRedemption event', async function () {

--- a/protocol/test/dao/State.test.js
+++ b/protocol/test/dao/State.test.js
@@ -211,6 +211,43 @@ describe('State', function () {
     });
   });
 
+  describe('updateEra', function () {
+    beforeEach('call', async function () {
+      await this.setters.incrementEpochE();
+    });
+
+    describe('before called', function () {
+      it('is 0', async function () {
+        expect(await this.setters.eraStatus()).to.be.bignumber.equal(new BN(0));
+        expect(await this.setters.eraStart()).to.be.bignumber.equal(new BN(0));
+      });
+    });
+
+    describe('when called change', function () {
+      beforeEach('call', async function () {
+        await this.setters.updateEraE(1);
+      });
+
+      it('is update', async function () {
+        expect(await this.setters.eraStatus()).to.be.bignumber.equal(new BN(1));
+        expect(await this.setters.eraStart()).to.be.bignumber.equal(new BN(1));
+      });
+    });
+
+    describe('when called twi', function () {
+      beforeEach('call', async function () {
+        await this.setters.updateEraE(1);
+        await this.setters.incrementEpochE();
+        await this.setters.updateEraE(0);
+      });
+
+      it('is update', async function () {
+        expect(await this.setters.eraStatus()).to.be.bignumber.equal(new BN(0));
+        expect(await this.setters.eraStart()).to.be.bignumber.equal(new BN(2));
+      });
+    });
+  });
+
   /**
    * Account
    */


### PR DESCRIPTION
# [Proposal 16]: Pro-Rated Premium

## Summary
- Implements [EIP-18](https://www.emptyset.xyz/t/eip-18-pro-rated-premium/208)

## Description
#### EIP-18
On redeem the premium portion of the user’s coupon will be pro-rated by the time their ESD was locked.

#### Migration
- Pro-Rated premiums apply to coupons purchased from epoch `420` onwards. (This will be bumped later as needed until it is proposed).

## Rewards
- Rewards `committer` with `1000 ESD`

## Tracking
Status: Pre-proposal
Implementation: 