### PR TITLE
[Proposal] 17: Stability Reward

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -75,6 +75,8 @@ library Constants {
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
     uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
     uint256 private constant TREASURY_RATIO = 250; // 2.5%
+    uint256 private constant STABILITY_REWARD_MIN = 0.3e14; // 0.3 bps
+    uint256 private constant STABILITY_REWARD_RATE = 5e14; // 5 bps
 
     /* Deployed */
     address private constant DAO_ADDRESS = address(0x443D2f2755DB5942601fa062Cc248aAA153313D3);
@@ -188,6 +190,14 @@ library Constants {
 
     function getTreasuryRatio() internal pure returns (uint256) {
         return TREASURY_RATIO;
+    }
+
+    function getStabilityRewardMin() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: STABILITY_REWARD_MIN});
+    }
+
+    function getStabilityRewardRate() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: STABILITY_REWARD_RATE});
     }
 
     function getChainId() internal pure returns (uint256) {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -23,8 +23,9 @@ import "./Regulator.sol";
 import "./Bonding.sol";
 import "./Govern.sol";
 import "../Constants.sol";
+import "./Stabilizer.sol";
 
-contract Implementation is State, Bonding, Market, Regulator, Govern {
+contract Implementation is State, Bonding, Market, Regulator, Stabilizer, Govern {
     using SafeMath for uint256;
 
     event Advance(uint256 indexed epoch, uint256 block, uint256 timestamp);
@@ -43,6 +44,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         Bonding.step();
         Regulator.step();
         Market.step();
+        Stabilizer.step();
 
         emit Advance(epoch(), block.number, block.timestamp);
     }

--- a/protocol/contracts/dao/Stabilizer.sol
+++ b/protocol/contracts/dao/Stabilizer.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.17;
+
+import "../Constants.sol";
+import "../external/Decimal.sol";
+import "./Setters.sol";
+import "./Comptroller.sol";
+
+contract Stabilizer is Setters, Comptroller {
+    event StabilityReward(uint256 indexed epoch, uint256 rate, uint256 amount);
+
+    function step() internal {
+        Decimal.D256 memory debtRatio = Decimal.ratio(totalDebt(), dollar().totalSupply());
+        debtRatio = debtRatio.greaterThan(Constants.getDebtRatioCap()) ? Constants.getDebtRatioCap() : debtRatio;
+
+        Decimal.D256 memory epochRate = Constants.getStabilityRewardMin().add(debtRatio.mul(Constants.getStabilityRewardRate()));
+        uint256 reward = epochRate.mul(totalBonded()).asUint256();
+        uint256 rewarded = stabilityReward(reward);
+
+        emit StabilityReward(epoch(), epochRate.value, rewarded);
+    }
+}

--- a/protocol/contracts/mock/MockComptroller.sol
+++ b/protocol/contracts/mock/MockComptroller.sol
@@ -55,6 +55,10 @@ contract MockComptroller is Comptroller, MockState {
         super.resetDebt(Decimal.ratio(percent, 100));
     }
 
+    function stabilityRewardE(uint256 amount) external {
+        super.stabilityReward(amount);
+    }
+
     /* For testing only */
     function mintToE(address account, uint256 amount) external {
         dollar().mint(account, amount);

--- a/protocol/contracts/mock/MockStabilizer.sol
+++ b/protocol/contracts/mock/MockStabilizer.sol
@@ -1,0 +1,30 @@
+/*
+    Copyright 2020 Empty Set Squad <emptysetsquad@protonmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity ^0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "./MockState.sol";
+import "../dao/Stabilizer.sol";
+import "./MockComptroller.sol";
+
+contract MockStabilizer is MockState, MockComptroller, Stabilizer {
+    constructor(address pool) MockComptroller(pool) public { }
+
+    function stepE() external {
+        super.step();
+    }
+}

--- a/protocol/test/dao/Comptroller.test.js
+++ b/protocol/test/dao/Comptroller.test.js
@@ -370,4 +370,32 @@ describe('Comptroller', function () {
       });
     });
   });
+
+  describe('stabilityReward', function () {
+    describe('no bonded', function () {
+      beforeEach(async function () {
+        await this.comptroller.stabilityRewardE(new BN(100));
+      });
+
+      it('doesnt mint Dollar tokens', async function () {
+        expect(await this.comptroller.totalBonded()).to.be.bignumber.equal(new BN(0));
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(0));
+        expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(0));
+      });
+    });
+
+    describe('no bonded', function () {
+      beforeEach(async function () {
+        await this.comptroller.mintToE(this.comptroller.address, new BN(1000));
+        await this.comptroller.incrementTotalBondedE(new BN(1000));
+        await this.comptroller.stabilityRewardE(new BN(100));
+      });
+
+      it('mints Dollar tokens', async function () {
+        expect(await this.comptroller.totalBonded()).to.be.bignumber.equal(new BN(1100));
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(new BN(1100));
+        expect(await this.dollar.balanceOf(this.comptroller.address)).to.be.bignumber.equal(new BN(1100));
+      });
+    });
+  });
 });

--- a/protocol/test/dao/Stabilizer.test.js
+++ b/protocol/test/dao/Stabilizer.test.js
@@ -1,0 +1,188 @@
+const { accounts, contract } = require('@openzeppelin/test-environment');
+
+const { BN, expectRevert, time, expectEvent } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+
+const MockStabilizer = contract.fromArtifact('MockStabilizer');
+const Dollar = contract.fromArtifact('Dollar');
+
+const ONE = new BN(10).pow(new BN(18));
+const ONE_MILLION = ONE.mul(new BN(1000000));
+
+describe('Stabilizer', function () {
+  const [ ownerAddress, poolAddress, circulating ] = accounts;
+
+  beforeEach(async function () {
+    this.stabilizer = await MockStabilizer.new(poolAddress, {from: ownerAddress, gas: 8000000});
+    this.dollar = await Dollar.at(await this.stabilizer.dollar());
+  });
+
+  describe('step', function () {
+    describe('no bonded', function () {
+      beforeEach(async function () {
+        await this.stabilizer.mintToE(circulating, ONE_MILLION);
+        await this.stabilizer.incrementEpochE();
+
+        this.result = await this.stabilizer.stepE();
+        this.txHash = this.result.tx;
+
+        this.stabilityReward = ONE.mul(new BN(30));
+      });
+
+      it('doesnt mint new Dollar tokens', async function () {
+        expect(await this.dollar.totalSupply()).to.be.bignumber.equal(ONE_MILLION);
+        expect(await this.dollar.balanceOf(this.stabilizer.address)).to.be.bignumber.equal(new BN(0));
+        expect(await this.dollar.balanceOf(circulating)).to.be.bignumber.equal(ONE_MILLION);
+      });
+
+      it('updates total redeemable', async function () {
+        expect(await this.stabilizer.totalBonded()).to.be.bignumber.equal(new BN(0));
+        expect(await this.stabilizer.totalSupply()).to.be.bignumber.equal(new BN(0));
+        expect(await this.stabilizer.totalDebt()).to.be.bignumber.equal(new BN(0));
+      });
+
+      it('emits StabilityReward event', async function () {
+        const event = await expectEvent.inTransaction(this.txHash, MockStabilizer, 'StabilityReward', {});
+
+        expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+        expect(event.args.rate).to.be.bignumber.equal(this.stabilityReward.divn(1000000));
+        expect(event.args.amount).to.be.bignumber.equal(new BN(0));
+      });
+    });
+
+    describe('bonded', function () {
+      beforeEach(async function () {
+        await this.stabilizer.mintToE(circulating, ONE_MILLION);
+        await this.stabilizer.mintToE(this.stabilizer.address, ONE_MILLION);
+        await this.stabilizer.incrementTotalBondedE(ONE_MILLION);
+
+        await this.stabilizer.incrementEpochE();
+      });
+
+      describe('no debt', function () {
+        beforeEach(async function () {
+          this.result = await this.stabilizer.stepE();
+          this.txHash = this.result.tx;
+
+          this.stabilityReward = ONE.mul(new BN(30));
+        });
+
+        it('doesnt mint new Dollar tokens', async function () {
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(ONE_MILLION.muln(2).add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(this.stabilizer.address)).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(circulating)).to.be.bignumber.equal(ONE_MILLION);
+        });
+
+        it('updates total redeemable', async function () {
+          expect(await this.stabilizer.totalBonded()).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.stabilizer.totalSupply()).to.be.bignumber.equal(new BN(0));
+          expect(await this.stabilizer.totalDebt()).to.be.bignumber.equal(new BN(0));
+        });
+
+        it('emits StabilityReward event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockStabilizer, 'StabilityReward', {});
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.rate).to.be.bignumber.equal(this.stabilityReward.divn(1000000));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(this.stabilityReward));
+        });
+      });
+
+      describe('some debt', function () {
+        beforeEach(async function () {
+          this.debt = ONE.muln(200000);
+          await this.stabilizer.incrementTotalDebtE(this.debt); // 10% debt ratio
+
+          this.result = await this.stabilizer.stepE();
+          this.txHash = this.result.tx;
+
+          this.stabilityReward = ONE.mul(new BN(30 + 50));
+        });
+
+        it('doesnt mint new Dollar tokens', async function () {
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(ONE_MILLION.muln(2).add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(this.stabilizer.address)).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(circulating)).to.be.bignumber.equal(ONE_MILLION);
+        });
+
+        it('updates total redeemable', async function () {
+          expect(await this.stabilizer.totalBonded()).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.stabilizer.totalSupply()).to.be.bignumber.equal(new BN(0));
+          expect(await this.stabilizer.totalDebt()).to.be.bignumber.equal(this.debt);
+        });
+
+        it('emits StabilityReward event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockStabilizer, 'StabilityReward', {});
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.rate).to.be.bignumber.equal(this.stabilityReward.divn(1000000));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(this.stabilityReward));
+        });
+      });
+
+      describe('max debt', function () {
+        beforeEach(async function () {
+          this.debt = ONE.muln(400000);
+          await this.stabilizer.incrementTotalDebtE(this.debt); // 20% debt ratio
+
+          this.result = await this.stabilizer.stepE();
+          this.txHash = this.result.tx;
+
+          this.stabilityReward = ONE.mul(new BN(30 + 100));
+        });
+
+        it('doesnt mint new Dollar tokens', async function () {
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(ONE_MILLION.muln(2).add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(this.stabilizer.address)).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(circulating)).to.be.bignumber.equal(ONE_MILLION);
+        });
+
+        it('updates total redeemable', async function () {
+          expect(await this.stabilizer.totalBonded()).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.stabilizer.totalSupply()).to.be.bignumber.equal(new BN(0));
+          expect(await this.stabilizer.totalDebt()).to.be.bignumber.equal( this.debt);
+        });
+
+        it('emits StabilityReward event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockStabilizer, 'StabilityReward', {});
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.rate).to.be.bignumber.equal(this.stabilityReward.divn(1000000));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(this.stabilityReward));
+        });
+      });
+
+      describe('above max debt', function () {
+        beforeEach(async function () {
+          this.debt = ONE.muln(1000000);
+          await this.stabilizer.incrementTotalDebtE(this.debt); // 50% debt ratio
+
+          this.result = await this.stabilizer.stepE();
+          this.txHash = this.result.tx;
+
+          this.stabilityReward = ONE.mul(new BN(30 + 100));
+        });
+
+        it('doesnt mint new Dollar tokens', async function () {
+          expect(await this.dollar.totalSupply()).to.be.bignumber.equal(ONE_MILLION.muln(2).add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(this.stabilizer.address)).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.dollar.balanceOf(circulating)).to.be.bignumber.equal(ONE_MILLION);
+        });
+
+        it('updates total redeemable', async function () {
+          expect(await this.stabilizer.totalBonded()).to.be.bignumber.equal(ONE_MILLION.add(this.stabilityReward));
+          expect(await this.stabilizer.totalSupply()).to.be.bignumber.equal(new BN(0));
+          expect(await this.stabilizer.totalDebt()).to.be.bignumber.equal( this.debt);
+        });
+
+        it('emits StabilityReward event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, MockStabilizer, 'StabilityReward', {});
+
+          expect(event.args.epoch).to.be.bignumber.equal(new BN(1));
+          expect(event.args.rate).to.be.bignumber.equal(this.stabilityReward.divn(1000000));
+          expect(event.args.amount).to.be.bignumber.equal(new BN(this.stabilityReward));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# [Proposal 17]: Stability Reward

## Summary
- Implements [EIP-22](https://www.emptyset.xyz/t/eip-22-dao-rewards/234)

## Description
#### EIP-22
Adds on always-on floating reward rate to the DAO to incentivize bonding during contraction periods.

### Reward calculation
`EPOCH_REWARD = TOTAL_BONDED * (REWARD_MIN + DEBT_RATIO * REWARD_RATE)`

#### Initial Constants
```
REWARD_MIN = 0.3 bps
REWARD_RATE = 5.0 bps
```

## Rewards
- Rewards `committer` with `1000 ESD`

## Tracking
Status: Pre-proposal
Implementation: 