### PR TITLE
[Cleanup] Fix compatibility with EIP-2612

### DIFF
--- a/protocol/contracts/token/Permittable.sol
+++ b/protocol/contracts/token/Permittable.sol
@@ -26,15 +26,15 @@ contract Permittable is ERC20Detailed, ERC20 {
     bytes32 constant FILE = "Permittable";
 
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 public constant EIP712_PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
     string private constant EIP712_VERSION = "1";
 
-    bytes32 public EIP712_DOMAIN_SEPARATOR;
+    bytes32 public DOMAIN_SEPARATOR;
 
-    mapping(address => uint256) nonces;
+    mapping(address => uint256) public nonces;
 
     constructor() public {
-        EIP712_DOMAIN_SEPARATOR = LibEIP712.hashEIP712Domain(name(), EIP712_VERSION, Constants.getChainId(), address(this));
+        DOMAIN_SEPARATOR = LibEIP712.hashEIP712Domain(name(), EIP712_VERSION, Constants.getChainId(), address(this));
     }
 
     function permit(
@@ -47,9 +47,9 @@ contract Permittable is ERC20Detailed, ERC20 {
         bytes32 s
     ) external {
         bytes32 digest = LibEIP712.hashEIP712Message(
-            EIP712_DOMAIN_SEPARATOR,
+            DOMAIN_SEPARATOR,
             keccak256(abi.encode(
-                EIP712_PERMIT_TYPEHASH,
+                PERMIT_TYPEHASH,
                 owner,
                 spender,
                 value,
@@ -63,12 +63,6 @@ contract Permittable is ERC20Detailed, ERC20 {
             recovered == owner,
             FILE,
             "Invalid signature"
-        );
-
-        Require.that(
-            recovered != address(0),
-            FILE,
-            "Zero address"
         );
 
         Require.that(


### PR DESCRIPTION
Addresses `L02` & `N04` from the OpenZeppelin v1 audit.

Updates `Permittable` (EIP-2612 implementation) contract:
- Though the `ESD` logically (and securely) supports EIP-2612, it does not properly surface all expected accompanying views, which may make it harder for wallets to support this feature
- Removes a redundant check

